### PR TITLE
bugfix python path of auto-cli

### DIFF
--- a/auto-tool/auto-cli/bin/pcc
+++ b/auto-tool/auto-cli/bin/pcc
@@ -5,6 +5,9 @@ import sys
 import re
 import json
 import subprocess
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
+
 import common.CommonUtils as CommonUtils
 #from common import CommonUtils
 import help.pcchelp as pcchelp

--- a/auto-tool/auto-cli/bin/pccrepo
+++ b/auto-tool/auto-cli/bin/pccrepo
@@ -6,6 +6,9 @@ import sys
 import re
 import json
 import subprocess
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
+
 import common.CommonUtils as CommonUtils
 from ast import literal_eval
 from optparse import OptionParser


### PR DESCRIPTION
python libのpathを通すように修正
