### PR TITLE
Support for Zabbix Server 2.2.X

### DIFF
--- a/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/Dockerfile
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/Dockerfile
@@ -1,0 +1,38 @@
+FROM centos:centos6
+
+RUN sed -i -e "s/tsflags=nodocs/#tsflags=nodocs/g" /etc/yum.conf
+
+# Install MySQL
+RUN yum install -y mysql-server
+
+COPY asset/my.cnf /etc/my.cnf
+RUN chmod 644 /etc/my.cnf
+RUN chown root:root /etc/my.cnf
+
+# Install Zabbix
+RUN rpm -ivh http://repo.zabbix.jp/relatedpkgs/rhel6/x86_64/zabbix-jp-release-6-6.noarch.rpm
+RUN yum install -y zabbix-server-mysql-1.8.15 zabbix-web-mysql-1.8.15
+
+COPY asset/zabbix.conf.php /etc/zabbix/zabbix.conf.php
+RUN chmod 600 /etc/zabbix/zabbix.conf.php
+RUN chown apache:apache /etc/zabbix/zabbix.conf.php
+
+# Initialize database
+RUN service mysqld start && \
+    mysql -e "grant all privileges on zabbix.* to zabbix@'localhost' identified by 'password';" && \
+    mysql -e "grant all privileges on zabbix.* to zabbix@'%' identified by 'password';" && \
+    mysql -e "create database zabbix;" && \
+    mysql -u zabbix -ppassword zabbix < /usr/share/doc/zabbix-server-1.8.15/schema/mysql.sql && \
+    mysql -u zabbix -ppassword zabbix < /usr/share/doc/zabbix-server-1.8.15/data/data.sql && \
+    mysql -u zabbix -ppassword zabbix < /usr/share/doc/zabbix-server-1.8.15/data/images_mysql.sql && \
+    mysql -e "INSERT INTO users VALUES (3,'api','api','api','5f4dcc3b5aa765d61d8327deb882cf99','',0,0,'en_gb',30,3,'default.css',0,'',0,50);" -u zabbix -ppassword zabbix && \
+    mysql -e "INSERT INTO users_groups VALUES (3,10,3);" -u zabbix -ppassword zabbix && \
+    service mysqld stop
+
+# Entrypoint
+COPY asset/entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+
+EXPOSE 80 3306
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/asset/entrypoint.sh
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/asset/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+service mysqld start
+service httpd start
+
+while true
+do
+    sleep 5
+done

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/asset/my.cnf
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/asset/my.cnf
@@ -1,0 +1,17 @@
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+user=mysql
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+character-set-server=utf8
+default-storage-engine=INNODB
+innodb_file_per_table
+
+[mysql]
+default-character-set=utf8
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/asset/zabbix.conf.php
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/asset/zabbix.conf.php
@@ -1,0 +1,20 @@
+<?php
+// Zabbix GUI configuration file
+global $DB;
+
+$DB['TYPE']     = 'MYSQL';
+$DB['SERVER']   = 'localhost';
+$DB['PORT']     = '0';
+$DB['DATABASE'] = 'zabbix';
+$DB['USER']     = 'zabbix';
+$DB['PASSWORD'] = 'password';
+
+// SCHEMA is relevant only for IBM_DB2 database
+$DB['SCHEMA'] = '';
+
+$ZBX_SERVER      = 'localhost';
+$ZBX_SERVER_PORT = '10051';
+$ZBX_SERVER_NAME = '';
+
+$IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;
+?>

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/docker-build.sh
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/docker-build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --no-cache --rm -t pcc-zabbix:1.8.15 .

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/docker-run.sh
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-1.8.15/docker-run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -i -t -p 80:80 -p 3306:3306 --name pcc-zabbix-1.8.15 -d pcc-zabbix:1.8.15

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/Dockerfile
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/Dockerfile
@@ -1,0 +1,42 @@
+FROM centos:centos6
+
+RUN sed -i -e "s/tsflags=nodocs/#tsflags=nodocs/g" /etc/yum.conf
+
+# Install MySQL
+RUN yum install -y mysql-server
+
+COPY asset/my.cnf /etc/my.cnf
+RUN chmod 644 /etc/my.cnf
+RUN chown root:root /etc/my.cnf
+
+# Install Zabbix
+RUN rpm -ivh http://repo.zabbix.com/zabbix/2.2/rhel/6/x86_64/zabbix-release-2.2-1.el6.noarch.rpm
+RUN yum install -y zabbix-server-mysql-2.2.9 zabbix-web-mysql-2.2.9 zabbix-web-japanese-2.2.9
+
+RUN localedef -f UTF-8 -i ja_JP ja_JP
+
+RUN sed -i -e "/php_value date.timezone/c \    php_value date.timezone Asia\/Tokyo" /etc/httpd/conf.d/zabbix.conf
+
+COPY asset/zabbix.conf.php /etc/zabbix/web/zabbix.conf.php
+RUN chmod 644 /etc/zabbix/web/zabbix.conf.php
+RUN chown apache:apache /etc/zabbix/web/zabbix.conf.php
+
+# Initialize database
+RUN service mysqld start && \
+    mysql -e "grant all privileges on zabbix.* to zabbix@'localhost' identified by 'password';" && \
+    mysql -e "grant all privileges on zabbix.* to zabbix@'%' identified by 'password';" && \
+    mysql -e "create database zabbix;" && \
+    mysql -u zabbix -ppassword zabbix < /usr/share/doc/zabbix-server-mysql-2.2.9/create/schema.sql && \
+    mysql -u zabbix -ppassword zabbix < /usr/share/doc/zabbix-server-mysql-2.2.9/create/images.sql && \
+    mysql -u zabbix -ppassword zabbix < /usr/share/doc/zabbix-server-mysql-2.2.9/create/data.sql && \
+    mysql -e "INSERT INTO users VALUES (3,'api','api','api','5f4dcc3b5aa765d61d8327deb882cf99','',0,900,'en_GB',30,3,'default',0,'',0,50);" -u zabbix -ppassword zabbix && \
+    mysql -e "INSERT INTO users_groups VALUES (5,12,3);" -u zabbix -ppassword zabbix && \
+    service mysqld stop
+
+# Entrypoint
+COPY asset/entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+
+EXPOSE 80 3306
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/asset/entrypoint.sh
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/asset/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+service mysqld start
+service httpd start
+
+while true
+do
+    sleep 5
+done

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/asset/my.cnf
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/asset/my.cnf
@@ -1,0 +1,17 @@
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+user=mysql
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+character-set-server=utf8
+default-storage-engine=INNODB
+innodb_file_per_table
+
+[mysql]
+default-character-set=utf8
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/asset/zabbix.conf.php
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/asset/zabbix.conf.php
@@ -1,0 +1,20 @@
+<?php
+// Zabbix GUI configuration file
+global $DB;
+
+$DB['TYPE']     = 'MYSQL';
+$DB['SERVER']   = 'localhost';
+$DB['PORT']     = '0';
+$DB['DATABASE'] = 'zabbix';
+$DB['USER']     = 'zabbix';
+$DB['PASSWORD'] = 'password';
+
+// SCHEMA is relevant only for IBM_DB2 database
+$DB['SCHEMA'] = '';
+
+$ZBX_SERVER      = 'localhost';
+$ZBX_SERVER_PORT = '10051';
+$ZBX_SERVER_NAME = '';
+
+$IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;
+?>

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/docker-build.sh
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/docker-build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --no-cache --rm -t pcc-zabbix:2.2.9 .

--- a/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/docker-run.sh
+++ b/auto-project/auto-zabbix/docker/pcc-zabbix-2.2.9/docker-run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -i -t -p 80:80 -p 3306:3306 --name pcc-zabbix-2.2.9 -d pcc-zabbix:2.2.9

--- a/auto-project/auto-zabbix/pom.xml
+++ b/auto-project/auto-zabbix/pom.xml
@@ -51,6 +51,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.18.1</version>
 				<configuration>
 					<excludes>
 						<exclude>jp/primecloud/auto/zabbix/client/APIInfoClientTest.java</exclude>

--- a/auto-project/auto-zabbix/pom.xml
+++ b/auto-project/auto-zabbix/pom.xml
@@ -47,4 +47,25 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>jp/primecloud/auto/zabbix/client/APIInfoClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/ApplicationClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/HostClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/HostgroupClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/ItemClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/ProxyClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/TemplateClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/TriggerClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/UserClientTest.java</exclude>
+						<exclude>jp/primecloud/auto/zabbix/client/UsergroupClientTest.java</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/ZabbixClient.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/ZabbixClient.java
@@ -90,7 +90,7 @@ public class ZabbixClient {
         JsonConfig config = new JsonConfig();
         PropertyNameProcessorMatcher matcher = new PropertyNameProcessorMatcher() {
             @Override
-            @SuppressWarnings("unchecked")
+            @SuppressWarnings("rawtypes")
             public Object getMatch(Class target, Set set) {
                 Object key = DEFAULT.getMatch(target, set);
                 if (key == null) {
@@ -105,6 +105,17 @@ public class ZabbixClient {
         config.registerJsonPropertyNameProcessor(Object.class, new JsonPropertyNameProcessor());
         config.setJsonPropertyFilter(new NullPropertyFilter());
         return config;
+    }
+
+    /**
+     * API実行対象のZabbix Serverのバージョンと指定したバージョンを比較します。<br/>
+     * 指定したバージョンと同じであれば0、指定したバージョンより後であれば0より大きい値、指定したバージョンより前であれば0より小さい値を返します。
+     * 
+     * @param zabbixVersion Zabbixバージョン
+     * @return
+     */
+    public int checkVersion(String zabbixVersion) {
+        return accessor.checkVersion(zabbixVersion);
     }
 
     public ZabbixAccessor getAccessor() {

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/APIInfoClient.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/APIInfoClient.java
@@ -51,7 +51,7 @@ public class APIInfoClient {
      * @return 取得したバージョン情報
      */
     public String version() {
-        return (String) accessor.execute("APIInfo.version", null);
+        return (String) accessor.execute("apiinfo.version", null);
     }
 
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/HostClient.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/HostClient.java
@@ -19,6 +19,7 @@
 package jp.primecloud.auto.zabbix.client;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,13 +30,12 @@ import jp.primecloud.auto.zabbix.model.host.HostCreateParam;
 import jp.primecloud.auto.zabbix.model.host.HostGetParam;
 import jp.primecloud.auto.zabbix.model.host.HostUpdateParam;
 import jp.primecloud.auto.zabbix.model.hostgroup.Hostgroup;
+import jp.primecloud.auto.zabbix.model.hostinterface.Hostinterface;
 import jp.primecloud.auto.zabbix.model.maintenance.Maintenance;
 import jp.primecloud.auto.zabbix.model.template.Template;
-
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JsonConfig;
-
 
 /**
  * <p>
@@ -70,6 +70,16 @@ public class HostClient {
     @SuppressWarnings("unchecked")
     public List<Host> get(HostGetParam param) {
         JSONObject params = JSONObject.fromObject(param, defaultConfig);
+        if (accessor.checkVersion("2.0") < 0) {
+            if (params.containsKey("selectGroups")) {
+                params.put("select_groups", params.remove("selectGroups"));
+            }
+        } else {
+            if (params.containsKey("output") && "extend".equals(params.getString("output"))) {
+                params.put("selectInterfaces", "extend");
+            }
+        }
+
         JSONArray result = (JSONArray) accessor.execute("host.get", params);
 
         JsonConfig config = defaultConfig.copy();
@@ -77,8 +87,37 @@ public class HostClient {
         config.setRootClass(Host.class);
         config.getClassMap().put("parenttemplates", Template.class);
         config.getClassMap().put("groups", Hostgroup.class);
+        config.getClassMap().put("interfaces", Hostinterface.class);
         config.getClassMap().put("maintenances", Maintenance.class);
-        return (List<Host>) JSONArray.toCollection(result, config);
+        List<Host> hosts = (List<Host>) JSONArray.toCollection(result, config);
+
+        // Zabbix 1.8用のインターフェースで2.0以降を操作できるようにするためのコード
+        if (accessor.checkVersion("2.0") >= 0) {
+            for (Host host : hosts) {
+                if (host.getInterfaces() != null && host.getInterfaces().size() > 0) {
+                    Hostinterface hostinterface = host.getInterfaces().get(0);
+                    host.setDns(hostinterface.getDns());
+                    host.setIp(hostinterface.getIp());
+                    host.setPort(hostinterface.getPort());
+                    host.setUseip(hostinterface.getUseip());
+                }
+            }
+        }
+        // Zabbix 2.0以降用のインターフェースで1.8を操作できるようにするためのコード
+        else {
+            for (Host host : hosts) {
+                Hostinterface hostinterface = new Hostinterface();
+                hostinterface.setDns(host.getDns());
+                hostinterface.setIp(host.getIp());
+                hostinterface.setPort(host.getPort());
+                hostinterface.setUseip(host.getUseip());
+                hostinterface.setType(1);
+                hostinterface.setMain(1);
+                host.setInterfaces(Arrays.asList(hostinterface));
+            }
+        }
+
+        return hosts;
     }
 
     /**
@@ -97,6 +136,37 @@ public class HostClient {
         if (param.getGroups() == null || param.getGroups().size() == 0) {
             throw new IllegalArgumentException("groups is required.");
         }
+
+        // Zabbix 1.8用のインターフェースで2.0以降を操作できるようにするためのコード
+        if (accessor.checkVersion("2.0") >= 0) {
+            if (param.getInterfaces() == null || param.getInterfaces().size() == 0) {
+                Hostinterface hostinterface = new Hostinterface();
+                hostinterface.setDns(param.getDns());
+                hostinterface.setIp((param.getIp() == null || param.getIp().length() == 0) ? "0.0.0.0" : param.getIp());
+                hostinterface.setPort((param.getPort() == null) ? 10050 : param.getPort());
+                hostinterface.setUseip((param.getUseip() == null) ? 0 : param.getUseip());
+                hostinterface.setType(1);
+                hostinterface.setMain(1);
+
+                param.setInterfaces(Arrays.asList(hostinterface));
+                param.setDns(null);
+                param.setIp(null);
+                param.setPort(null);
+                param.setUseip(null);
+            }
+        }
+        // Zabbix 2.0以降用のインターフェースで1.8を操作できるようにするためのコード
+        else {
+            if (param.getInterfaces() != null && param.getInterfaces().size() > 0) {
+                Hostinterface hostinterface = param.getInterfaces().get(0);
+                param.setDns(hostinterface.getDns());
+                param.setIp(hostinterface.getIp());
+                param.setPort(hostinterface.getPort());
+                param.setUseip(hostinterface.getUseip());
+                param.setInterfaces(null);
+            }
+        }
+
         JSONObject params = JSONObject.fromObject(param, defaultConfig);
         JSONObject result = (JSONObject) accessor.execute("host.create", params);
 
@@ -124,6 +194,58 @@ public class HostClient {
         if (param.getGroups() != null && param.getGroups().size() == 0) {
             throw new IllegalArgumentException("groups must be null or not empty.");
         }
+
+        // Zabbix 1.8用のインターフェースで2.0以降を操作できるようにするためのコード
+        if (accessor.checkVersion("2.0") >= 0) {
+            if (param.getDns() != null && param.getIp() != null) {
+                if (param.getInterfaces() == null || param.getInterfaces().size() == 0) {
+                    // interfaceidを取得
+                    String interfaceid = null;
+                    {
+                        HostGetParam hostGetParam = new HostGetParam();
+                        hostGetParam.setHostids(Arrays.asList(param.getHostid()));
+                        hostGetParam.setOutput("extend");
+
+                        List<Host> hosts = get(hostGetParam);
+                        if (hosts.size() > 0) {
+                            Host host = hosts.get(0);
+                            if (host.getInterfaces() != null && host.getInterfaces().size() > 0) {
+                                interfaceid = host.getInterfaces().get(0).getInterfaceid();
+                            }
+                        }
+                    }
+
+                    Hostinterface hostinterface = new Hostinterface();
+                    hostinterface.setInterfaceid(interfaceid);
+                    hostinterface.setDns(param.getDns());
+                    hostinterface.setHostid(param.getHostid());
+                    hostinterface.setIp((param.getIp() == null || param.getIp().length() == 0) ? "0.0.0.0" : param
+                            .getIp());
+                    hostinterface.setPort((param.getPort() == null) ? 10050 : param.getPort());
+                    hostinterface.setUseip((param.getUseip() == null) ? 0 : param.getUseip());
+                    hostinterface.setType(1);
+                    hostinterface.setMain(1);
+
+                    param.setInterfaces(Arrays.asList(hostinterface));
+                    param.setDns(null);
+                    param.setIp(null);
+                    param.setPort(null);
+                    param.setUseip(null);
+                }
+            }
+        }
+        // Zabbix 2.0以降用のインターフェースで1.8を操作できるようにするためのコード
+        else {
+            if (param.getInterfaces() != null && param.getInterfaces().size() > 0) {
+                Hostinterface hostinterface = param.getInterfaces().get(0);
+                param.setDns(hostinterface.getDns());
+                param.setIp(hostinterface.getIp());
+                param.setPort(hostinterface.getPort());
+                param.setUseip(hostinterface.getUseip());
+                param.setInterfaces(null);
+            }
+        }
+
         JSONObject params = JSONObject.fromObject(param, defaultConfig);
         JSONObject result = (JSONObject) accessor.execute("host.update", params);
 
@@ -148,8 +270,8 @@ public class HostClient {
             throw new IllegalArgumentException("hostid is required.");
         }
 
-        List<Map<String, String>> list = new ArrayList<Map<String,String>>();
-        for (String hostid: hostids) {
+        List<Map<String, String>> list = new ArrayList<Map<String, String>>();
+        for (String hostid : hostids) {
             Map<String, String> map = new HashMap<String, String>();
             map.put("hostid", hostid);
             list.add(map);

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/HostgroupClient.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/HostgroupClient.java
@@ -135,13 +135,19 @@ public class HostgroupClient {
             throw new IllegalArgumentException("groupid is required.");
         }
 
-        List<Map<String, String>> list = new ArrayList<Map<String,String>>();
-        for (String groupid: groupids) {
-            Map<String, String> map = new HashMap<String, String>();
-            map.put("groupid", groupid);
-            list.add(map);
+        JSONArray params;
+        if (accessor.checkVersion("2.0") < 0) {
+            List<Map<String, String>> list = new ArrayList<Map<String, String>>();
+            for (String groupid : groupids) {
+                Map<String, String> map = new HashMap<String, String>();
+                map.put("groupid", groupid);
+                list.add(map);
+            }
+            params = JSONArray.fromObject(list, defaultConfig);
+        } else {
+            params = JSONArray.fromObject(groupids, defaultConfig);
         }
-        JSONArray params = JSONArray.fromObject(list, defaultConfig);
+
         JSONObject result = (JSONObject) accessor.execute("hostgroup.delete", params);
 
         JSONArray hostgroupids = result.getJSONArray("groupids");

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/TriggerClient.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/TriggerClient.java
@@ -18,18 +18,15 @@
  */
 package jp.primecloud.auto.zabbix.client;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import jp.primecloud.auto.zabbix.ZabbixAccessor;
 import jp.primecloud.auto.zabbix.model.trigger.Trigger;
 import jp.primecloud.auto.zabbix.model.trigger.TriggerGetParam;
-
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JsonConfig;
 import net.sf.json.util.PropertyFilter;
-
 
 /**
  * <p>
@@ -62,24 +59,22 @@ public class TriggerClient {
      */
     @SuppressWarnings("unchecked")
     public List<Trigger> get(TriggerGetParam param) {
-        //2012.10.24 現在、PCCでは使用していない
-//        JSONObject params = JSONObject.fromObject(param, defaultConfig);
-//        JSONArray result = (JSONArray) accessor.execute("trigger.get", params);
-//
-//        JsonConfig config = defaultConfig.copy();
-//        config.setCollectionType(List.class);
-//        config.setRootClass(Trigger.class);
-//        config.setJavaPropertyFilter(new PropertyFilter() {
-//            @Override
-//            public boolean apply(Object source, String name, Object value) {
-//                if ("hosts".equals(name)) {
-//                    return true;
-//                }
-//                return false;
-//            }
-//        });
-//
-//        return (List<Trigger>) JSONArray.toCollection(result, config);
-        return new ArrayList<Trigger>();
+        JSONObject params = JSONObject.fromObject(param, defaultConfig);
+        JSONArray result = (JSONArray) accessor.execute("trigger.get", params);
+
+        JsonConfig config = defaultConfig.copy();
+        config.setCollectionType(List.class);
+        config.setRootClass(Trigger.class);
+        config.setJavaPropertyFilter(new PropertyFilter() {
+            @Override
+            public boolean apply(Object source, String name, Object value) {
+                if ("hosts".equals(name)) {
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        return (List<Trigger>) JSONArray.toCollection(result, config);
     }
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/package-info.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/client/package-info.java
@@ -1,6 +1,6 @@
 /**
  * <p>
- * TODO: パッケージコメントを記述
+ * Zabbix APIを操作するクラスです。
  * </p>
  */
 package jp.primecloud.auto.zabbix.client;

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/application/Application.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/application/Application.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import jp.primecloud.auto.zabbix.model.host.Host;
 
-
 /**
  * <p>
  * Applicationのエンティティクラスです。
@@ -36,9 +35,13 @@ public class Application implements Serializable {
 
     private String applicationid;
 
+    private String hostid;
+
     private List<Host> hosts;
 
     private String name;
+
+    private List<String> templateids;
 
     private String templateid;
 
@@ -58,6 +61,24 @@ public class Application implements Serializable {
      */
     public void setApplicationid(String applicationid) {
         this.applicationid = applicationid;
+    }
+
+    /**
+     * hostidを取得します。
+     *
+     * @return hostid
+     */
+    public String getHostid() {
+        return hostid;
+    }
+
+    /**
+     * hostidを設定します。
+     *
+     * @param hostid String
+     */
+    public void setHostid(String hostid) {
+        this.hostid = hostid;
     }
 
     /**
@@ -94,6 +115,24 @@ public class Application implements Serializable {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * templateidsを取得します。
+     *
+     * @return templateids
+     */
+    public List<String> getTemplateids() {
+        return templateids;
+    }
+
+    /**
+     * templateidsを設定します。
+     *
+     * @param templateids List<String>
+     */
+    public void setTemplateids(List<String> templateids) {
+        this.templateids = templateids;
     }
 
     /**

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/Host.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/Host.java
@@ -22,9 +22,9 @@ import java.io.Serializable;
 import java.util.List;
 
 import jp.primecloud.auto.zabbix.model.hostgroup.Hostgroup;
+import jp.primecloud.auto.zabbix.model.hostinterface.Hostinterface;
 import jp.primecloud.auto.zabbix.model.maintenance.Maintenance;
 import jp.primecloud.auto.zabbix.model.template.Template;
-
 
 /**
  * <p>
@@ -104,11 +104,27 @@ public class Host implements Serializable {
 
     private String snmpError;
 
+    private String jmxDisableUntil;
+
+    private String jmxAvailable;
+
+    private String jmxErrorsFrom;
+
+    private String jmxError;
+
+    private String name;
+
+    private String flags;
+
+    private String templateid;
+
     private List<Template> parenttemplates;
 
     private List <Hostgroup> groups;
 
     private List<Maintenance> maintenances;
+
+    private List<Hostinterface> interfaces;
 
     /**
      * hostidを取得します。
@@ -723,6 +739,132 @@ public class Host implements Serializable {
     }
 
     /**
+     * jmxDisableUntilを取得します。
+     *
+     * @return jmxDisableUntil
+     */
+    public String getJmxDisableUntil() {
+        return jmxDisableUntil;
+    }
+
+    /**
+     * jmxDisableUntilを設定します。
+     *
+     * @param jmxDisableUntil String
+     */
+    public void setJmxDisableUntil(String jmxDisableUntil) {
+        this.jmxDisableUntil = jmxDisableUntil;
+    }
+
+    /**
+     * jmxAvailableを取得します。
+     *
+     * @return jmxAvailable
+     */
+    public String getJmxAvailable() {
+        return jmxAvailable;
+    }
+
+    /**
+     * jmxAvailableを設定します。
+     *
+     * @param jmxAvailable String
+     */
+    public void setJmxAvailable(String jmxAvailable) {
+        this.jmxAvailable = jmxAvailable;
+    }
+
+    /**
+     * jmxErrorsFromを取得します。
+     *
+     * @return jmxErrorsFrom
+     */
+    public String getJmxErrorsFrom() {
+        return jmxErrorsFrom;
+    }
+
+    /**
+     * jmxErrorsFromを設定します。
+     *
+     * @param jmxErrorsFrom String
+     */
+    public void setJmxErrorsFrom(String jmxErrorsFrom) {
+        this.jmxErrorsFrom = jmxErrorsFrom;
+    }
+
+    /**
+     * jmxErrorを取得します。
+     *
+     * @return jmxError
+     */
+    public String getJmxError() {
+        return jmxError;
+    }
+
+    /**
+     * jmxErrorを設定します。
+     *
+     * @param jmxError String
+     */
+    public void setJmxError(String jmxError) {
+        this.jmxError = jmxError;
+    }
+
+    /**
+     * nameを取得します。
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * nameを設定します。
+     *
+     * @param name String
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * flagsを取得します。
+     *
+     * @return flags
+     */
+    public String getFlags() {
+        return flags;
+    }
+
+    /**
+     * flagsを設定します。
+     *
+     * @param flags String
+     */
+    public void setFlags(String flags) {
+        this.flags = flags;
+    }
+
+    /**
+     * templateidを取得します。
+     *
+     * @return templateid
+     */
+    public String getTemplateid() {
+        return templateid;
+    }
+
+    /**
+     * templateidを設定します。
+     *
+     * @param templateid String
+     */
+    public void setTemplateid(String templateid) {
+        this.templateid = templateid;
+    }
+
+    /**
      * parenttemplatesを取得します。
      *
      * @return parenttemplates
@@ -775,4 +917,23 @@ public class Host implements Serializable {
     public void setMaintenances(List<Maintenance> maintenances) {
         this.maintenances = maintenances;
     }
+
+    /**
+     * interfacesを取得します。
+     *
+     * @return interfaces
+     */
+    public List<Hostinterface> getInterfaces() {
+        return interfaces;
+    }
+
+    /**
+     * interfacesを設定します。
+     *
+     * @param interfaces List<Hostinterface>
+     */
+    public void setInterfaces(List<Hostinterface> interfaces) {
+        this.interfaces = interfaces;
+    }
+
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/HostCreateParam.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/HostCreateParam.java
@@ -22,8 +22,8 @@ import java.io.Serializable;
 import java.util.List;
 
 import jp.primecloud.auto.zabbix.model.hostgroup.Hostgroup;
+import jp.primecloud.auto.zabbix.model.hostinterface.Hostinterface;
 import jp.primecloud.auto.zabbix.model.template.Template;
-
 
 /**
  * <p>
@@ -38,6 +38,8 @@ public class HostCreateParam implements Serializable {
     private String host;
 
     private List<Hostgroup> groups;
+
+    private List<Hostinterface> interfaces;
 
     private List<Template> templates;
 
@@ -87,6 +89,24 @@ public class HostCreateParam implements Serializable {
      */
     public void setGroups(List<Hostgroup> groups) {
         this.groups = groups;
+    }
+
+    /**
+     * interfacesを取得します。
+     *
+     * @return interfaces
+     */
+    public List<Hostinterface> getInterfaces() {
+        return interfaces;
+    }
+
+    /**
+     * interfacesを設定します。
+     *
+     * @param interfaces List<Hostinterface>
+     */
+    public void setInterfaces(List<Hostinterface> interfaces) {
+        this.interfaces = interfaces;
     }
 
     /**

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/HostGetParam.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/HostGetParam.java
@@ -38,6 +38,8 @@ public class HostGetParam implements Serializable {
 
     private String selectGroups;
 
+    private String selectInterfaces;
+
     private String selectParentTemplates;
 
     private Map<String, List<Object>> filter;
@@ -112,6 +114,24 @@ public class HostGetParam implements Serializable {
      */
     public void setSelectGroups(String selectGroups) {
         this.selectGroups = selectGroups;
+    }
+
+    /**
+     * selectInterfacesを取得します。
+     *
+     * @return selectInterfaces
+     */
+    public String getSelectInterfaces() {
+        return selectInterfaces;
+    }
+
+    /**
+     * selectInterfacesを設定します。
+     *
+     * @param selectInterfaces String
+     */
+    public void setSelectInterfaces(String selectInterfaces) {
+        this.selectInterfaces = selectInterfaces;
     }
 
     /**

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/HostUpdateParam.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/host/HostUpdateParam.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.List;
 
 import jp.primecloud.auto.zabbix.model.hostgroup.Hostgroup;
+import jp.primecloud.auto.zabbix.model.hostinterface.Hostinterface;
 import jp.primecloud.auto.zabbix.model.template.Template;
 
 
@@ -40,6 +41,8 @@ public class HostUpdateParam implements Serializable {
     private String host;
 
     private List<Hostgroup> groups;
+
+    private List<Hostinterface> interfaces;
 
     private List<Template> templates;
 
@@ -107,6 +110,24 @@ public class HostUpdateParam implements Serializable {
      */
     public void setGroups(List<Hostgroup> groups) {
         this.groups = groups;
+    }
+
+    /**
+     * interfacesを取得します。
+     *
+     * @return interfaces
+     */
+    public List<Hostinterface> getInterfaces() {
+        return interfaces;
+    }
+
+    /**
+     * interfacesを設定します。
+     *
+     * @param interfaces List<Hostinterface>
+     */
+    public void setInterfaces(List<Hostinterface> interfaces) {
+        this.interfaces = interfaces;
     }
 
     /**

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/hostgroup/Hostgroup.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/hostgroup/Hostgroup.java
@@ -34,6 +34,8 @@ public class Hostgroup implements Serializable {
 
     private String name;
 
+    private Integer flags;
+
     private Integer internal;
 
     /**
@@ -70,6 +72,24 @@ public class Hostgroup implements Serializable {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * flagsを取得します。
+     *
+     * @return flags
+     */
+    public Integer getFlags() {
+        return flags;
+    }
+
+    /**
+     * flagsを設定します。
+     *
+     * @param flags Integer
+     */
+    public void setFlags(Integer flags) {
+        this.flags = flags;
     }
 
     /**

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/hostinterface/Hostinterface.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/hostinterface/Hostinterface.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2015 by SCSK Corporation.
+ * 
+ * This file is part of PrimeCloud Controller(TM).
+ * 
+ * PrimeCloud Controller(TM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * PrimeCloud Controller(TM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with PrimeCloud Controller(TM). If not, see <http://www.gnu.org/licenses/>.
+ */
+package jp.primecloud.auto.zabbix.model.hostinterface;
+
+import java.io.Serializable;
+
+/**
+ * <p>
+ * Hostinterfaceのエンティティクラスです。
+ * </p>
+ *
+ */
+public class Hostinterface implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String interfaceid;
+
+    private String dns;
+
+    private String hostid;
+
+    private String ip;
+
+    private Integer main;
+
+    private Integer port;
+
+    private Integer type;
+
+    private Integer useip;
+
+    /**
+     * interfaceidを取得します。
+     * 
+     * @return interfaceid
+     */
+    public String getInterfaceid() {
+        return interfaceid;
+    }
+
+    /**
+     * interfaceidを設定します。
+     * 
+     * @param interfaceid String
+     */
+    public void setInterfaceid(String interfaceid) {
+        this.interfaceid = interfaceid;
+    }
+
+    /**
+     * dnsを取得します。
+     * 
+     * @return dns
+     */
+    public String getDns() {
+        return dns;
+    }
+
+    /**
+     * dnsを設定します。
+     * 
+     * @param dns String
+     */
+    public void setDns(String dns) {
+        this.dns = dns;
+    }
+
+    /**
+     * hostidを取得します。
+     * 
+     * @return hostid
+     */
+    public String getHostid() {
+        return hostid;
+    }
+
+    /**
+     * hostidを設定します。
+     * 
+     * @param hostid String
+     */
+    public void setHostid(String hostid) {
+        this.hostid = hostid;
+    }
+
+    /**
+     * ipを取得します。
+     * 
+     * @return ip
+     */
+    public String getIp() {
+        return ip;
+    }
+
+    /**
+     * ipを設定します。
+     * 
+     * @param ip String
+     */
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    /**
+     * mainを取得します。
+     * 
+     * @return main
+     */
+    public Integer getMain() {
+        return main;
+    }
+
+    /**
+     * mainを設定します。
+     * 
+     * @param main Integer
+     */
+    public void setMain(Integer main) {
+        this.main = main;
+    }
+
+    /**
+     * portを取得します。
+     * 
+     * @return port
+     */
+    public Integer getPort() {
+        return port;
+    }
+
+    /**
+     * portを設定します。
+     * 
+     * @param port Integer
+     */
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    /**
+     * typeを取得します。
+     * 
+     * @return type
+     */
+    public Integer getType() {
+        return type;
+    }
+
+    /**
+     * typeを設定します。
+     * 
+     * @param type Integer
+     */
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    /**
+     * useipを取得します。
+     * 
+     * @return useip
+     */
+    public Integer getUseip() {
+        return useip;
+    }
+
+    /**
+     * useipを設定します。
+     * 
+     * @param useip Integer
+     */
+    public void setUseip(Integer useip) {
+        this.useip = useip;
+    }
+
+}

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/item/Item.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/item/Item.java
@@ -19,6 +19,7 @@
 package jp.primecloud.auto.zabbix.model.item;
 
 import java.io.Serializable;
+
 /**
  * <p>
  * Itemのエンティティクラスです。
@@ -112,6 +113,30 @@ public class Item implements Serializable {
     private Integer mtime;
 
     private String application;
+
+    private String name;
+
+    private Integer flags;
+
+    private String interfaceid;
+
+    private String port;
+
+    private Integer inventoryLink;
+
+    private Integer state;
+
+    private Integer snmpv3Authprotocol;
+
+    private Integer snmpv3Privprotocol;
+
+    private String snmpv3Contextname;
+
+    private Integer lastns;
+
+    private String filter;
+
+    private Integer lifetime;
 
     /**
      * itemidを取得します。
@@ -867,6 +892,234 @@ public class Item implements Serializable {
      */
     public void setApplication(String application) {
         this.application = application;
+    }
+
+    /**
+     * nameを取得します。
+     *
+     * @return name
+     */
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * nameを設定します。
+     *
+     * @param name name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * flagsを取得します。
+     *
+     * @return flags
+     */
+
+    public Integer getFlags() {
+        return flags;
+    }
+
+    /**
+     * flagsを設定します。
+     *
+     * @param flags flags
+     */
+    public void setFlags(Integer flags) {
+        this.flags = flags;
+    }
+
+    /**
+     * interfaceidを取得します。
+     *
+     * @return interfaceid
+     */
+
+    public String getInterfaceid() {
+        return interfaceid;
+    }
+
+    /**
+     * interfaceidを設定します。
+     *
+     * @param interfaceid interfaceid
+     */
+    public void setInterfaceid(String interfaceid) {
+        this.interfaceid = interfaceid;
+    }
+
+    /**
+     * portを取得します。
+     *
+     * @return port
+     */
+
+    public String getPort() {
+        return port;
+    }
+
+    /**
+     * portを設定します。
+     *
+     * @param port port
+     */
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    /**
+     * inventoryLinkを取得します。
+     *
+     * @return inventoryLink
+     */
+
+    public Integer getInventoryLink() {
+        return inventoryLink;
+    }
+
+    /**
+     * inventoryLinkを設定します。
+     *
+     * @param inventoryLink inventoryLink
+     */
+    public void setInventoryLink(Integer inventoryLink) {
+        this.inventoryLink = inventoryLink;
+    }
+
+    /**
+     * stateを取得します。
+     *
+     * @return state
+     */
+
+    public Integer getState() {
+        return state;
+    }
+
+    /**
+     * stateを設定します。
+     *
+     * @param state state
+     */
+    public void setState(Integer state) {
+        this.state = state;
+    }
+
+    /**
+     * snmpv3Authprotocolを取得します。
+     *
+     * @return snmpv3Authprotocol
+     */
+
+    public Integer getSnmpv3Authprotocol() {
+        return snmpv3Authprotocol;
+    }
+
+    /**
+     * snmpv3Authprotocolを設定します。
+     *
+     * @param snmpv3Authprotocol snmpv3Authprotocol
+     */
+    public void setSnmpv3Authprotocol(Integer snmpv3Authprotocol) {
+        this.snmpv3Authprotocol = snmpv3Authprotocol;
+    }
+
+    /**
+     * snmpv3Privprotocolを取得します。
+     *
+     * @return snmpv3Privprotocol
+     */
+
+    public Integer getSnmpv3Privprotocol() {
+        return snmpv3Privprotocol;
+    }
+
+    /**
+     * snmpv3Privprotocolを設定します。
+     *
+     * @param snmpv3Privprotocol snmpv3Privprotocol
+     */
+    public void setSnmpv3Privprotocol(Integer snmpv3Privprotocol) {
+        this.snmpv3Privprotocol = snmpv3Privprotocol;
+    }
+
+    /**
+     * snmpv3Contextnameを取得します。
+     *
+     * @return snmpv3Contextname
+     */
+
+    public String getSnmpv3Contextname() {
+        return snmpv3Contextname;
+    }
+
+    /**
+     * snmpv3Contextnameを設定します。
+     *
+     * @param snmpv3Contextname snmpv3Contextname
+     */
+    public void setSnmpv3Contextname(String snmpv3Contextname) {
+        this.snmpv3Contextname = snmpv3Contextname;
+    }
+
+    /**
+     * lastnsを取得します。
+     *
+     * @return lastns
+     */
+
+    public Integer getLastns() {
+        return lastns;
+    }
+
+    /**
+     * lastnsを設定します。
+     *
+     * @param lastns lastns
+     */
+    public void setLastns(Integer lastns) {
+        this.lastns = lastns;
+    }
+
+    /**
+     * filterを取得します。
+     *
+     * @return filter
+     */
+
+    public String getFilter() {
+        return filter;
+    }
+
+    /**
+     * filterを設定します。
+     *
+     * @param filter filter
+     */
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    /**
+     * lifetimeを取得します。
+     *
+     * @return lifetime
+     */
+
+    public Integer getLifetime() {
+        return lifetime;
+    }
+
+    /**
+     * lifetimeを設定します。
+     *
+     * @param lifetime lifetime
+     */
+    public void setLifetime(Integer lifetime) {
+        this.lifetime = lifetime;
     }
 
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/proxy/Proxy.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/proxy/Proxy.java
@@ -36,6 +36,64 @@ public class Proxy implements Serializable {
 
     private Integer status;
 
+    private Integer lastaccess;
+
+    private String proxyHostid;
+
+    private Integer disableUntil;
+
+    private String error;
+
+    private Integer available;
+
+    private Integer errorsFrom;
+
+    private Integer ipmiAuthtype;
+
+    private Integer ipmiPrivilege;
+
+    private String ipmiUsername;
+
+    private String ipmiPassword;
+
+    private Integer ipmiDisableUntil;
+
+    private Integer ipmiAvailable;
+
+    private Integer snmpDisableUntil;
+
+    private Integer snmpAvailable;
+
+    private Integer maintenanceid;
+
+    private Integer maintenanceStatus;
+
+    private Integer maintenanceType;
+
+    private Integer maintenanceFrom;
+
+    private Integer ipmiErrorsFrom;
+
+    private Integer snmpErrorsFrom;
+
+    private String ipmiError;
+
+    private String snmpError;
+
+    private String jmxDisableUntil;
+
+    private String jmxAvailable;
+
+    private String jmxErrorsFrom;
+
+    private String jmxError;
+
+    private String name;
+
+    private String flags;
+
+    private String templateid;
+
     /**
      * proxyidを取得します。
      *
@@ -89,4 +147,556 @@ public class Proxy implements Serializable {
     public void setStatus(Integer status) {
         this.status = status;
     }
+
+    /**
+     * lastaccessを取得します。
+     *
+     * @return lastaccess
+     */
+
+    public Integer getLastaccess() {
+        return lastaccess;
+    }
+
+    /**
+     * lastaccessを設定します。
+     *
+     * @param lastaccess lastaccess
+     */
+    public void setLastaccess(Integer lastaccess) {
+        this.lastaccess = lastaccess;
+    }
+
+    /**
+     * proxyHostidを取得します。
+     *
+     * @return proxyHostid
+     */
+
+    public String getProxyHostid() {
+        return proxyHostid;
+    }
+
+    /**
+     * proxyHostidを設定します。
+     *
+     * @param proxyHostid proxyHostid
+     */
+    public void setProxyHostid(String proxyHostid) {
+        this.proxyHostid = proxyHostid;
+    }
+
+    /**
+     * disableUntilを取得します。
+     *
+     * @return disableUntil
+     */
+
+    public Integer getDisableUntil() {
+        return disableUntil;
+    }
+
+    /**
+     * disableUntilを設定します。
+     *
+     * @param disableUntil disableUntil
+     */
+    public void setDisableUntil(Integer disableUntil) {
+        this.disableUntil = disableUntil;
+    }
+
+    /**
+     * errorを取得します。
+     *
+     * @return error
+     */
+
+    public String getError() {
+        return error;
+    }
+
+    /**
+     * errorを設定します。
+     *
+     * @param error error
+     */
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    /**
+     * availableを取得します。
+     *
+     * @return available
+     */
+
+    public Integer getAvailable() {
+        return available;
+    }
+
+    /**
+     * availableを設定します。
+     *
+     * @param available available
+     */
+    public void setAvailable(Integer available) {
+        this.available = available;
+    }
+
+    /**
+     * errorsFromを取得します。
+     *
+     * @return errorsFrom
+     */
+
+    public Integer getErrorsFrom() {
+        return errorsFrom;
+    }
+
+    /**
+     * errorsFromを設定します。
+     *
+     * @param errorsFrom errorsFrom
+     */
+    public void setErrorsFrom(Integer errorsFrom) {
+        this.errorsFrom = errorsFrom;
+    }
+
+    /**
+     * ipmiAuthtypeを取得します。
+     *
+     * @return ipmiAuthtype
+     */
+
+    public Integer getIpmiAuthtype() {
+        return ipmiAuthtype;
+    }
+
+    /**
+     * ipmiAuthtypeを設定します。
+     *
+     * @param ipmiAuthtype ipmiAuthtype
+     */
+    public void setIpmiAuthtype(Integer ipmiAuthtype) {
+        this.ipmiAuthtype = ipmiAuthtype;
+    }
+
+    /**
+     * ipmiPrivilegeを取得します。
+     *
+     * @return ipmiPrivilege
+     */
+
+    public Integer getIpmiPrivilege() {
+        return ipmiPrivilege;
+    }
+
+    /**
+     * ipmiPrivilegeを設定します。
+     *
+     * @param ipmiPrivilege ipmiPrivilege
+     */
+    public void setIpmiPrivilege(Integer ipmiPrivilege) {
+        this.ipmiPrivilege = ipmiPrivilege;
+    }
+
+    /**
+     * ipmiUsernameを取得します。
+     *
+     * @return ipmiUsername
+     */
+
+    public String getIpmiUsername() {
+        return ipmiUsername;
+    }
+
+    /**
+     * ipmiUsernameを設定します。
+     *
+     * @param ipmiUsername ipmiUsername
+     */
+    public void setIpmiUsername(String ipmiUsername) {
+        this.ipmiUsername = ipmiUsername;
+    }
+
+    /**
+     * ipmiPasswordを取得します。
+     *
+     * @return ipmiPassword
+     */
+
+    public String getIpmiPassword() {
+        return ipmiPassword;
+    }
+
+    /**
+     * ipmiPasswordを設定します。
+     *
+     * @param ipmiPassword ipmiPassword
+     */
+    public void setIpmiPassword(String ipmiPassword) {
+        this.ipmiPassword = ipmiPassword;
+    }
+
+    /**
+     * ipmiDisableUntilを取得します。
+     *
+     * @return ipmiDisableUntil
+     */
+
+    public Integer getIpmiDisableUntil() {
+        return ipmiDisableUntil;
+    }
+
+    /**
+     * ipmiDisableUntilを設定します。
+     *
+     * @param ipmiDisableUntil ipmiDisableUntil
+     */
+    public void setIpmiDisableUntil(Integer ipmiDisableUntil) {
+        this.ipmiDisableUntil = ipmiDisableUntil;
+    }
+
+    /**
+     * ipmiAvailableを取得します。
+     *
+     * @return ipmiAvailable
+     */
+
+    public Integer getIpmiAvailable() {
+        return ipmiAvailable;
+    }
+
+    /**
+     * ipmiAvailableを設定します。
+     *
+     * @param ipmiAvailable ipmiAvailable
+     */
+    public void setIpmiAvailable(Integer ipmiAvailable) {
+        this.ipmiAvailable = ipmiAvailable;
+    }
+
+    /**
+     * snmpDisableUntilを取得します。
+     *
+     * @return snmpDisableUntil
+     */
+
+    public Integer getSnmpDisableUntil() {
+        return snmpDisableUntil;
+    }
+
+    /**
+     * snmpDisableUntilを設定します。
+     *
+     * @param snmpDisableUntil snmpDisableUntil
+     */
+    public void setSnmpDisableUntil(Integer snmpDisableUntil) {
+        this.snmpDisableUntil = snmpDisableUntil;
+    }
+
+    /**
+     * snmpAvailableを取得します。
+     *
+     * @return snmpAvailable
+     */
+
+    public Integer getSnmpAvailable() {
+        return snmpAvailable;
+    }
+
+    /**
+     * snmpAvailableを設定します。
+     *
+     * @param snmpAvailable snmpAvailable
+     */
+    public void setSnmpAvailable(Integer snmpAvailable) {
+        this.snmpAvailable = snmpAvailable;
+    }
+
+    /**
+     * maintenanceidを取得します。
+     *
+     * @return maintenanceid
+     */
+
+    public Integer getMaintenanceid() {
+        return maintenanceid;
+    }
+
+    /**
+     * maintenanceidを設定します。
+     *
+     * @param maintenanceid maintenanceid
+     */
+    public void setMaintenanceid(Integer maintenanceid) {
+        this.maintenanceid = maintenanceid;
+    }
+
+    /**
+     * maintenanceStatusを取得します。
+     *
+     * @return maintenanceStatus
+     */
+
+    public Integer getMaintenanceStatus() {
+        return maintenanceStatus;
+    }
+
+    /**
+     * maintenanceStatusを設定します。
+     *
+     * @param maintenanceStatus maintenanceStatus
+     */
+    public void setMaintenanceStatus(Integer maintenanceStatus) {
+        this.maintenanceStatus = maintenanceStatus;
+    }
+
+    /**
+     * maintenanceTypeを取得します。
+     *
+     * @return maintenanceType
+     */
+
+    public Integer getMaintenanceType() {
+        return maintenanceType;
+    }
+
+    /**
+     * maintenanceTypeを設定します。
+     *
+     * @param maintenanceType maintenanceType
+     */
+    public void setMaintenanceType(Integer maintenanceType) {
+        this.maintenanceType = maintenanceType;
+    }
+
+    /**
+     * maintenanceFromを取得します。
+     *
+     * @return maintenanceFrom
+     */
+
+    public Integer getMaintenanceFrom() {
+        return maintenanceFrom;
+    }
+
+    /**
+     * maintenanceFromを設定します。
+     *
+     * @param maintenanceFrom maintenanceFrom
+     */
+    public void setMaintenanceFrom(Integer maintenanceFrom) {
+        this.maintenanceFrom = maintenanceFrom;
+    }
+
+    /**
+     * ipmiErrorsFromを取得します。
+     *
+     * @return ipmiErrorsFrom
+     */
+
+    public Integer getIpmiErrorsFrom() {
+        return ipmiErrorsFrom;
+    }
+
+    /**
+     * ipmiErrorsFromを設定します。
+     *
+     * @param ipmiErrorsFrom ipmiErrorsFrom
+     */
+    public void setIpmiErrorsFrom(Integer ipmiErrorsFrom) {
+        this.ipmiErrorsFrom = ipmiErrorsFrom;
+    }
+
+    /**
+     * snmpErrorsFromを取得します。
+     *
+     * @return snmpErrorsFrom
+     */
+
+    public Integer getSnmpErrorsFrom() {
+        return snmpErrorsFrom;
+    }
+
+    /**
+     * snmpErrorsFromを設定します。
+     *
+     * @param snmpErrorsFrom snmpErrorsFrom
+     */
+    public void setSnmpErrorsFrom(Integer snmpErrorsFrom) {
+        this.snmpErrorsFrom = snmpErrorsFrom;
+    }
+
+    /**
+     * ipmiErrorを取得します。
+     *
+     * @return ipmiError
+     */
+
+    public String getIpmiError() {
+        return ipmiError;
+    }
+
+    /**
+     * ipmiErrorを設定します。
+     *
+     * @param ipmiError ipmiError
+     */
+    public void setIpmiError(String ipmiError) {
+        this.ipmiError = ipmiError;
+    }
+
+    /**
+     * snmpErrorを取得します。
+     *
+     * @return snmpError
+     */
+
+    public String getSnmpError() {
+        return snmpError;
+    }
+
+    /**
+     * snmpErrorを設定します。
+     *
+     * @param snmpError snmpError
+     */
+    public void setSnmpError(String snmpError) {
+        this.snmpError = snmpError;
+    }
+
+    /**
+     * jmxDisableUntilを取得します。
+     *
+     * @return jmxDisableUntil
+     */
+
+    public String getJmxDisableUntil() {
+        return jmxDisableUntil;
+    }
+
+    /**
+     * jmxDisableUntilを設定します。
+     *
+     * @param jmxDisableUntil jmxDisableUntil
+     */
+    public void setJmxDisableUntil(String jmxDisableUntil) {
+        this.jmxDisableUntil = jmxDisableUntil;
+    }
+
+    /**
+     * jmxAvailableを取得します。
+     *
+     * @return jmxAvailable
+     */
+
+    public String getJmxAvailable() {
+        return jmxAvailable;
+    }
+
+    /**
+     * jmxAvailableを設定します。
+     *
+     * @param jmxAvailable jmxAvailable
+     */
+    public void setJmxAvailable(String jmxAvailable) {
+        this.jmxAvailable = jmxAvailable;
+    }
+
+    /**
+     * jmxErrorsFromを取得します。
+     *
+     * @return jmxErrorsFrom
+     */
+
+    public String getJmxErrorsFrom() {
+        return jmxErrorsFrom;
+    }
+
+    /**
+     * jmxErrorsFromを設定します。
+     *
+     * @param jmxErrorsFrom jmxErrorsFrom
+     */
+    public void setJmxErrorsFrom(String jmxErrorsFrom) {
+        this.jmxErrorsFrom = jmxErrorsFrom;
+    }
+
+    /**
+     * jmxErrorを取得します。
+     *
+     * @return jmxError
+     */
+
+    public String getJmxError() {
+        return jmxError;
+    }
+
+    /**
+     * jmxErrorを設定します。
+     *
+     * @param jmxError jmxError
+     */
+    public void setJmxError(String jmxError) {
+        this.jmxError = jmxError;
+    }
+
+    /**
+     * nameを取得します。
+     *
+     * @return name
+     */
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * nameを設定します。
+     *
+     * @param name name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * flagsを取得します。
+     *
+     * @return flags
+     */
+
+    public String getFlags() {
+        return flags;
+    }
+
+    /**
+     * flagsを設定します。
+     *
+     * @param flags flags
+     */
+    public void setFlags(String flags) {
+        this.flags = flags;
+    }
+
+    /**
+     * templateidを取得します。
+     *
+     * @return templateid
+     */
+
+    public String getTemplateid() {
+        return templateid;
+    }
+
+    /**
+     * templateidを設定します。
+     *
+     * @param templateid templateid
+     */
+    public void setTemplateid(String templateid) {
+        this.templateid = templateid;
+    }
+
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/template/Template.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/template/Template.java
@@ -100,6 +100,18 @@ public class Template implements Serializable {
 
     private String snmpError;
 
+    private String jmxDisableUntil;
+
+    private String jmxAvailable;
+
+    private String jmxErrorsFrom;
+
+    private String jmxError;
+
+    private String name;
+
+    private String flags;
+
     /**
      * templateidを取得します。
      *
@@ -728,6 +740,114 @@ public class Template implements Serializable {
      */
     public void setSnmpError(String snmpError) {
         this.snmpError = snmpError;
+    }
+
+    /**
+     * jmxDisableUntilを取得します。
+     *
+     * @return jmxDisableUntil
+     */
+    public String getJmxDisableUntil() {
+        return jmxDisableUntil;
+    }
+
+    /**
+     * jmxDisableUntilを設定します。
+     *
+     * @param jmxDisableUntil String
+     */
+    public void setJmxDisableUntil(String jmxDisableUntil) {
+        this.jmxDisableUntil = jmxDisableUntil;
+    }
+
+    /**
+     * jmxAvailableを取得します。
+     *
+     * @return jmxAvailable
+     */
+    public String getJmxAvailable() {
+        return jmxAvailable;
+    }
+
+    /**
+     * jmxAvailableを設定します。
+     *
+     * @param jmxAvailable String
+     */
+    public void setJmxAvailable(String jmxAvailable) {
+        this.jmxAvailable = jmxAvailable;
+    }
+
+    /**
+     * jmxErrorsFromを取得します。
+     *
+     * @return jmxErrorsFrom
+     */
+    public String getJmxErrorsFrom() {
+        return jmxErrorsFrom;
+    }
+
+    /**
+     * jmxErrorsFromを設定します。
+     *
+     * @param jmxErrorsFrom String
+     */
+    public void setJmxErrorsFrom(String jmxErrorsFrom) {
+        this.jmxErrorsFrom = jmxErrorsFrom;
+    }
+
+    /**
+     * jmxErrorを取得します。
+     *
+     * @return jmxError
+     */
+    public String getJmxError() {
+        return jmxError;
+    }
+
+    /**
+     * jmxErrorを設定します。
+     *
+     * @param jmxError String
+     */
+    public void setJmxError(String jmxError) {
+        this.jmxError = jmxError;
+    }
+
+    /**
+     * nameを取得します。
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * nameを設定します。
+     *
+     * @param name String
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * flagsを取得します。
+     *
+     * @return flags
+     */
+    public String getFlags() {
+        return flags;
+    }
+
+    /**
+     * flagsを設定します。
+     *
+     * @param flags String
+     */
+    public void setFlags(String flags) {
+        this.flags = flags;
     }
 
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/trigger/Trigger.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/trigger/Trigger.java
@@ -32,6 +32,8 @@ public class Trigger implements Serializable {
 
     private String triggerid;
 
+    private String hostid;
+
     private String expression;
 
     private String description;
@@ -56,6 +58,12 @@ public class Trigger implements Serializable {
 
     private Integer type;
 
+    private Integer state;
+
+    private Integer flags;
+
+    private Integer valueFlags;
+
     /**
      * triggeridを取得します。
      *
@@ -72,6 +80,25 @@ public class Trigger implements Serializable {
      */
     public void setTriggerid(String triggerid) {
         this.triggerid = triggerid;
+    }
+
+    /**
+     * hostidを取得します。
+     *
+     * @return hostid
+     */
+
+    public String getHostid() {
+        return hostid;
+    }
+
+    /**
+     * hostidを設定します。
+     *
+     * @param hostid hostid
+     */
+    public void setHostid(String hostid) {
+        this.hostid = hostid;
     }
 
     /**
@@ -288,6 +315,63 @@ public class Trigger implements Serializable {
      */
     public void setType(Integer type) {
         this.type = type;
+    }
+
+    /**
+     * stateを取得します。
+     *
+     * @return state
+     */
+
+    public Integer getState() {
+        return state;
+    }
+
+    /**
+     * stateを設定します。
+     *
+     * @param state state
+     */
+    public void setState(Integer state) {
+        this.state = state;
+    }
+
+    /**
+     * flagsを取得します。
+     *
+     * @return flags
+     */
+
+    public Integer getFlags() {
+        return flags;
+    }
+
+    /**
+     * flagsを設定します。
+     *
+     * @param flags flags
+     */
+    public void setFlags(Integer flags) {
+        this.flags = flags;
+    }
+
+    /**
+     * valueFlagsを取得します。
+     *
+     * @return valueFlags
+     */
+
+    public Integer getValueFlags() {
+        return valueFlags;
+    }
+
+    /**
+     * valueFlagsを設定します。
+     *
+     * @param valueFlags valueFlags
+     */
+    public void setValueFlags(Integer valueFlags) {
+        this.valueFlags = valueFlags;
     }
 
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/user/User.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/user/User.java
@@ -19,6 +19,9 @@
 package jp.primecloud.auto.zabbix.model.user;
 
 import java.io.Serializable;
+import java.util.List;
+
+import jp.primecloud.auto.zabbix.model.usergroup.Usergroup;
 
 /**
  * <p>
@@ -61,6 +64,8 @@ public class User implements Serializable {
     private Integer attemptClock;
 
     private Integer rowsPerPage;
+
+    private List<Usergroup> usrgrps;
 
     /**
      * useridを取得します。
@@ -348,6 +353,25 @@ public class User implements Serializable {
      */
     public void setRowsPerPage(Integer rowsPerPage) {
         this.rowsPerPage = rowsPerPage;
+    }
+
+    /**
+     * usrgrpsを取得します。
+     *
+     * @return usrgrps
+     */
+
+    public List<Usergroup> getUsrgrps() {
+        return usrgrps;
+    }
+
+    /**
+     * usrgrpsを設定します。
+     *
+     * @param usrgrps usrgrps
+     */
+    public void setUsrgrps(List<Usergroup> usrgrps) {
+        this.usrgrps = usrgrps;
     }
 
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/user/UserGetParam.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/model/user/UserGetParam.java
@@ -35,6 +35,8 @@ public class UserGetParam implements Serializable {
 
     private String output;
 
+    private String selectUsrgrps;
+
     /**
      * useridsを取得します。
      *
@@ -70,4 +72,24 @@ public class UserGetParam implements Serializable {
     public void setOutput(String output) {
         this.output = output;
     }
+
+    /**
+     * selectUsrgrpsを取得します。
+     *
+     * @return selectUsrgrps
+     */
+
+    public String getSelectUsrgrps() {
+        return selectUsrgrps;
+    }
+
+    /**
+     * selectUsrgrpsを設定します。
+     *
+     * @param selectUsrgrps selectUsrgrps
+     */
+    public void setSelectUsrgrps(String selectUsrgrps) {
+        this.selectUsrgrps = selectUsrgrps;
+    }
+
 }

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/util/JavaPropertyNameProcessor.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/util/JavaPropertyNameProcessor.java
@@ -24,7 +24,7 @@ import net.sf.json.processors.PropertyNameProcessor;
 
 /**
  * <p>
- * TODO: クラスコメントを記述
+ * JSONのキーをJavaのプロパティ名にマッピングするクラスです。
  * </p>
  *
  */
@@ -34,7 +34,7 @@ public class JavaPropertyNameProcessor implements PropertyNameProcessor {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("rawtypes")
     public String processPropertyName(Class beanClass, String name) {
         if (name == null || name.length() == 0) {
             return name;

--- a/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/util/JsonPropertyNameProcessor.java
+++ b/auto-project/auto-zabbix/src/main/java/jp/primecloud/auto/zabbix/util/JsonPropertyNameProcessor.java
@@ -20,11 +20,13 @@ package jp.primecloud.auto.zabbix.util;
 
 import java.util.Locale;
 
+import jp.primecloud.auto.zabbix.model.host.HostGetParam;
+import jp.primecloud.auto.zabbix.model.user.UserGetParam;
 import net.sf.json.processors.PropertyNameProcessor;
 
 /**
  * <p>
- * TODO: クラスコメントを記述
+ * Javaのプロパティ名をJSONのキーにマッピングするクラスです。
  * </p>
  *
  */
@@ -34,10 +36,25 @@ public class JsonPropertyNameProcessor implements PropertyNameProcessor {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("rawtypes")
     public String processPropertyName(Class beanClass, String name) {
-        if (name == null || name.length() == 0 || "selectParentTemplates".equals(name)) {
+        if (name == null || name.length() == 0) {
             return name;
+        }
+
+        if (beanClass != null) {
+            if (HostGetParam.class.isAssignableFrom(beanClass)) {
+                if (name.equals("selectParentTemplates")) {
+                    return name;
+                } else if (name.equals("selectGroups")) {
+                    return name;
+                }
+            }
+            if (UserGetParam.class.isAssignableFrom(beanClass)) {
+                if (name.equals("selectUsrgrps")) {
+                    return name;
+                }
+            }
         }
 
         StringBuilder sb = new StringBuilder();

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/ZabbixAccessorTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/ZabbixAccessorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 by SCSK Corporation.
+ * 
+ * This file is part of PrimeCloud Controller(TM).
+ * 
+ * PrimeCloud Controller(TM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * PrimeCloud Controller(TM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with PrimeCloud Controller(TM). If not, see <http://www.gnu.org/licenses/>.
+ */
+package jp.primecloud.auto.zabbix;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * <p>
+ * {@link ZabbixAccessor}のテストクラスです。
+ * </p>
+ * 
+ */
+public class ZabbixAccessorTest {
+
+    @Test
+    public void testCompareVersion() {
+        ZabbixAccessor accessor = ZabbixAccessor.getInstance(null, null, null, null);
+
+        assertTrue(accessor.compareVersion("1.0", "1.8") == 0);
+        assertTrue(accessor.compareVersion("1.1", "1.8.1") == 0);
+        assertTrue(accessor.compareVersion("1.2", "1.8.2") == 0);
+        assertTrue(accessor.compareVersion("1.3", "1.8.3") == 0);
+        assertTrue(accessor.compareVersion("1.3", "1.8.15") == 0);
+        assertTrue(accessor.compareVersion("1.4", "2.0.0") == 0);
+        assertTrue(accessor.compareVersion("1.4", "2.0.3") == 0);
+        assertTrue(accessor.compareVersion("2.0.4", "2.0.4") == 0);
+        assertTrue(accessor.compareVersion("2.2.9", "2.2.9") == 0);
+
+        assertTrue(accessor.compareVersion("1.3", "2.0") < 0);
+        assertTrue(accessor.compareVersion("3.0.0", "2.2.9") > 0);
+    }
+
+}

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/APIInfoClientTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/APIInfoClientTest.java
@@ -18,20 +18,15 @@
  */
 package jp.primecloud.auto.zabbix.client;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Properties;
 
 import jp.primecloud.auto.zabbix.ZabbixClient;
 import jp.primecloud.auto.zabbix.ZabbixClientFactory;
-import jp.primecloud.auto.zabbix.client.APIInfoClient;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-
 
 /**
  * <p>
@@ -62,11 +57,9 @@ public class APIInfoClientTest {
     }
 
     @Test
-    @Ignore
     public void testVersion() {
         String version = client.APIInfo().version();
         log.trace(version);
-        assertEquals("1.2", version);
     }
 
 }

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/ProxyClientTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/ProxyClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 by SCSK Corporation.
+ * Copyright 2015 by SCSK Corporation.
  * 
  * This file is part of PrimeCloud Controller(TM).
  * 
@@ -22,30 +22,33 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import jp.primecloud.auto.zabbix.ZabbixClient;
 import jp.primecloud.auto.zabbix.ZabbixClientFactory;
-import jp.primecloud.auto.zabbix.model.application.Application;
-import jp.primecloud.auto.zabbix.model.application.ApplicationGetParam;
+import jp.primecloud.auto.zabbix.model.proxy.Proxy;
+import jp.primecloud.auto.zabbix.model.proxy.ProxyGetParam;
 
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * <p>
- * {@link ApplicationClient}のテストクラスです。
+ * {@link ProxyClient}のテストクラスです。
  * </p>
  *
  */
-public class ApplicationClientTest {
+public class ProxyClientTest {
 
-    private Log log = LogFactory.getLog(ApplicationClientTest.class);
+    private Log log = LogFactory.getLog(ProxyClientTest.class);
 
     private ZabbixClient client;
 
@@ -66,57 +69,34 @@ public class ApplicationClientTest {
     }
 
     @Test
+    @Ignore
     public void testGetAll() {
         // 全件取得
-        ApplicationGetParam param = new ApplicationGetParam();
+        ProxyGetParam param = new ProxyGetParam();
         param.setOutput("extend");
 
-        List<Application> applications = client.application().get(param);
-        for (Application application : applications) {
-            log.trace(ReflectionToStringBuilder.toString(application, ToStringStyle.SHORT_PREFIX_STYLE));
+        List<Proxy> proxies = client.proxy().get(param);
+        for (Proxy proxy : proxies) {
+            log.trace(ReflectionToStringBuilder.toString(proxy, ToStringStyle.SHORT_PREFIX_STYLE));
         }
 
-        assertTrue(applications.size() > 0);
+        assertTrue(proxies.size() > 0);
     }
 
     @Test
-    public void testGet() {
-        // applicationidを指定して取得
-        ApplicationGetParam param = new ApplicationGetParam();
-        param.setApplicationids(Arrays.asList("1"));
+    @Ignore
+    public void testGetByFilter() {
+        // 存在するproxy名を指定した場合
+        ProxyGetParam param = new ProxyGetParam();
         param.setOutput("extend");
 
-        List<Application> applications = client.application().get(param);
-        assertEquals(1, applications.size());
-        assertEquals("1", applications.get(0).getApplicationid());
-    }
+        Map<String, List<Object>> filter = new HashMap<String, List<Object>>();
+        filter.put("host", Arrays.asList((Object) "proxy1"));
+        param.setFilter(filter);
 
-    @Test
-    public void testGetNotExist() {
-        // 存在しないapplicationidを指定した場合
-        ApplicationGetParam param = new ApplicationGetParam();
-        param.setApplicationids(Arrays.asList("999999"));
-        param.setOutput("extend");
-
-        List<Application> applications = client.application().get(param);
-        assertEquals(0, applications.size());
-    }
-
-    @Test
-    public void testGetByTemplateid() {
-        String templateid = "10001";
-
-        ApplicationGetParam param = new ApplicationGetParam();
-        // templateidをhostidに指定する
-        param.setHostids(Arrays.asList(templateid));
-        param.setOutput("extend");
-
-        List<Application> applications = client.application().get(param);
-        for (Application application : applications) {
-            log.trace(ReflectionToStringBuilder.toString(application, ToStringStyle.SHORT_PREFIX_STYLE));
-        }
-
-        assertTrue(applications.size() > 0);
+        List<Proxy> proxies = client.proxy().get(param);
+        assertEquals(1, proxies.size());
+        assertEquals("proxy1", proxies.get(0).getHost());
     }
 
 }

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/TemplateClientTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/TemplateClientTest.java
@@ -107,16 +107,23 @@ public class TemplateClientTest {
     @Test
     public void testGetByFilter() {
         // 存在するtemplate名を指定した場合
+        String templateName;
+        if (client.checkVersion("2.0") < 0) {
+            templateName = "Template_Linux";
+        } else {
+            templateName = "Template OS Linux";
+        }
+
         TemplateGetParam param = new TemplateGetParam();
         param.setOutput("extend");
 
         Map<String, List<Object>> filter = new HashMap<String, List<Object>>();
-        filter.put("host", Arrays.asList((Object) "Template_Linux"));
+        filter.put("host", Arrays.asList((Object) templateName));
         param.setFilter(filter);
 
         List<Template> templates = client.template().get(param);
         assertEquals(1, templates.size());
-        assertEquals("Template_Linux", templates.get(0).getHost());
+        assertEquals(templateName, templates.get(0).getHost());
     }
 
     @Test

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/TemplateClientTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/TemplateClientTest.java
@@ -19,8 +19,8 @@
 package jp.primecloud.auto.zabbix.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -29,7 +29,6 @@ import java.util.Properties;
 
 import jp.primecloud.auto.zabbix.ZabbixClient;
 import jp.primecloud.auto.zabbix.ZabbixClientFactory;
-import jp.primecloud.auto.zabbix.client.TemplateClient;
 import jp.primecloud.auto.zabbix.model.template.Template;
 import jp.primecloud.auto.zabbix.model.template.TemplateGetParam;
 
@@ -38,9 +37,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-
 
 /**
  * <p>
@@ -71,84 +68,66 @@ public class TemplateClientTest {
     }
 
     @Test
-    @Ignore
+    public void testGetAll() {
+        // 全件取得
+        TemplateGetParam param = new TemplateGetParam();
+        param.setOutput("extend");
+
+        List<Template> templates = client.template().get(param);
+        for (Template template : templates) {
+            log.trace(ReflectionToStringBuilder.toString(template, ToStringStyle.SHORT_PREFIX_STYLE));
+        }
+
+        assertTrue(templates.size() > 0);
+    }
+
+    @Test
     public void testGet() {
-        // 全件取得
+        // templateidを指定して取得
         TemplateGetParam param = new TemplateGetParam();
-        param.setOutput("extend");
-        List<Template> templates = client.template().get(param);
-
-        for (Template template : templates) {
-            log.trace(ReflectionToStringBuilder.toString(template, ToStringStyle.SHORT_PREFIX_STYLE));
-        }
-
-        if (templates.size() > 0) {
-            // templateidを指定して取得
-            List<String> tempids = new ArrayList<String>();
-            tempids.add(templates.get(0).getTemplateid());
-            param.setTemplateids(tempids);
-            List<Template> templates2 = client.template().get(param);
-
-            assertEquals(1, templates2.size());
-            assertEquals(templates.get(0).getTemplateid(), templates2.get(0).getTemplateid());
-        }
-    }
-
-    @Test
-    @Ignore
-    public void testGet5() {
-        // 全件取得
-        TemplateGetParam param = new TemplateGetParam();
-        List<String> templateids = new ArrayList<String>();
-        //templateids.add("11022");
-        templateids.add("10057");
-        param.setTemplateids(templateids);
-        param.setOutput("extend");
-        List<Template> templates = client.template().get(param);
-
-        for (Template template : templates) {
-            log.trace(ReflectionToStringBuilder.toString(template, ToStringStyle.SHORT_PREFIX_STYLE));
-        }
-
-    }
-
-    @Test
-    @Ignore
-    public void testGet2() {
-        // 存在しないtemplateidを指定した場合
-        TemplateGetParam param = new TemplateGetParam();
-        List<String> templateids = new ArrayList<String>();
-        templateids.add("999999");
-        param.setTemplateids(templateids);
-        List<Template> temps = client.template().get(param);
-        assertEquals(0, temps.size());
-    }
-
-    @Test
-    @Ignore
-    public void testGet3() {
-        // 存在するtemplate名を指定した場合
-        TemplateGetParam param = new TemplateGetParam();
-        Map<String, List<Object>> filter = new HashMap<String, List<Object>>();
-        filter.put("host", Arrays.asList((Object)"Template_OS_Linux"));
-        param.setFilter(filter);
+        param.setTemplateids(Arrays.asList("10001"));
         param.setOutput("extend");
 
         List<Template> templates = client.template().get(param);
         assertEquals(1, templates.size());
-        assertEquals("10057", templates.get(0).getTemplateid());
-        assertEquals("Template_OS_Linux", templates.get(0).getHost());
+        assertEquals("10001", templates.get(0).getTemplateid());
     }
 
     @Test
-    @Ignore
-    public void testGet4() {
+    public void testGetNotExist() {
+        // 存在しないtemplateidを指定した場合
+        TemplateGetParam param = new TemplateGetParam();
+        param.setTemplateids(Arrays.asList("999999"));
+        param.setOutput("extend");
+
+        List<Template> templates = client.template().get(param);
+        assertEquals(0, templates.size());
+    }
+
+    @Test
+    public void testGetByFilter() {
+        // 存在するtemplate名を指定した場合
+        TemplateGetParam param = new TemplateGetParam();
+        param.setOutput("extend");
+
+        Map<String, List<Object>> filter = new HashMap<String, List<Object>>();
+        filter.put("host", Arrays.asList((Object) "Template_Linux"));
+        param.setFilter(filter);
+
+        List<Template> templates = client.template().get(param);
+        assertEquals(1, templates.size());
+        assertEquals("Template_Linux", templates.get(0).getHost());
+    }
+
+    @Test
+    public void testGetByFilter2() {
         // 存在しないtemplate名を指定した場合
         TemplateGetParam param = new TemplateGetParam();
-        Map<String, List<Object>> filter = new HashMap<String, List<Object>>();
-        filter.put("host", Arrays.asList((Object)"dummy"));
-        param.setFilter(filter);
         param.setOutput("extend");
+
+        Map<String, List<Object>> filter = new HashMap<String, List<Object>>();
+        filter.put("host", Arrays.asList((Object) "dummy"));
+        param.setFilter(filter);
 
         List<Template> templates = client.template().get(param);
         assertEquals(0, templates.size());

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/TriggerClientTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/TriggerClientTest.java
@@ -18,7 +18,10 @@
  */
 package jp.primecloud.auto.zabbix.client;
 
-import java.util.ArrayList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
@@ -32,12 +35,15 @@ import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
-
+/**
+ * <p>
+ * {@link TriggerClient}のテストクラスです。
+ * </p>
+ *
+ */
 public class TriggerClientTest {
-
 
     private Log log = LogFactory.getLog(TriggerClientTest.class);
 
@@ -60,32 +66,32 @@ public class TriggerClientTest {
     }
 
     @Test
-    @Ignore
-    public void testGet() {
+    public void testGetAll() {
         // 全件取得
         TriggerGetParam param = new TriggerGetParam();
-     //    List<String> list = new ArrayList<String>();
-      //    list.add("19944");
-     //     param.setTriggerids(list);
+        param.setHostids(Arrays.asList("10001"));
         param.setOutput("extend");
-        List<String> hostids = new ArrayList<String>();
-        hostids.add("10001");
-        param.setHostids(hostids);
+
+        List<Trigger> triggers = client.trigger().get(param);
+        for (Trigger trigger : triggers) {
+            log.trace(ReflectionToStringBuilder.toString(trigger, ToStringStyle.SHORT_PREFIX_STYLE));
+        }
+
+        assertTrue(triggers.size() > 0);
+    }
+
+    @Test
+    public void testGet() {
+        // itemidを指定して取得
+        TriggerGetParam param = new TriggerGetParam();
+        param.setTriggerids(Arrays.asList("10010", "10011"));
+        param.setOutput("extend");
+
         List<Trigger> triggers = client.trigger().get(param);
 
-        for (Trigger trigger : triggers) {
-            log.debug(ReflectionToStringBuilder.toString(trigger, ToStringStyle.SHORT_PREFIX_STYLE));
-
-        }
-        /*        if (triggers.size() > 0) {
-                    // TriggerIdを指定して取得
-                    List<Integer> triggerIds = new ArrayList<Integer>();
-                    triggerIds.add(triggers.get(0).getTriggerId());
-                    param.set(tempids);
-                    List<Template> templates2 = client.template().get(param);
-
-                    assertEquals(1, templates2.size());
-                    assertEquals(templates.get(0).getTemplateid(), templates2.get(0).getTemplateid());
-                }*/
+        assertEquals(2, triggers.size());
+        assertTrue("10010".equals(triggers.get(0).getTriggerid()) || "10011".equals(triggers.get(0).getTriggerid()));
+        assertTrue("10010".equals(triggers.get(1).getTriggerid()) || "10011".equals(triggers.get(1).getTriggerid()));
     }
+
 }

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/UserClientTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/UserClientTest.java
@@ -19,16 +19,15 @@
 package jp.primecloud.auto.zabbix.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
 import jp.primecloud.auto.zabbix.ZabbixClient;
 import jp.primecloud.auto.zabbix.ZabbixClientFactory;
-import jp.primecloud.auto.zabbix.client.UserClient;
 import jp.primecloud.auto.zabbix.model.user.User;
 import jp.primecloud.auto.zabbix.model.user.UserAuthenticateParam;
 import jp.primecloud.auto.zabbix.model.user.UserCreateParam;
@@ -40,9 +39,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-
 
 /**
  * <p>
@@ -73,7 +70,6 @@ public class UserClientTest {
     }
 
     @Test
-    @Ignore
     public void testLogin() throws Exception {
         Properties properties = new Properties();
         properties.load(getClass().getResourceAsStream("/zabbix.properties"));
@@ -83,17 +79,18 @@ public class UserClientTest {
         UserAuthenticateParam param = new UserAuthenticateParam();
         param.setUser(username);
         param.setPassword(password);
+
         String sessionId = client.user().login(param);
         log.trace(sessionId);
     }
 
     @Test
-    @Ignore
     public void testLogin2() {
         // 認証情報が誤っている場合
         UserAuthenticateParam param = new UserAuthenticateParam();
         param.setUser("dummy");
         param.setPassword("dummy");
+
         try {
             client.user().login(param);
             fail();
@@ -103,80 +100,161 @@ public class UserClientTest {
     }
 
     @Test
-    @Ignore
-    public void testGet() {
+    public void testGetAll() {
         // 全件取得
         UserGetParam param = new UserGetParam();
         param.setOutput("extend");
+
         List<User> users = client.user().get(param);
         for (User user : users) {
             log.trace(ReflectionToStringBuilder.toString(user, ToStringStyle.SHORT_PREFIX_STYLE));
         }
 
-        if (users.size() > 0) {
-            // useridを指定して取得
-            List<String> userids = new ArrayList<String>();
-            userids.add(users.get(0).getUserid());
-            param.setUserids(userids);
-            List<User> users2 = client.user().get(param);
-
-            assertEquals(1, users2.size());
-            assertEquals(users.get(0).getUserid(), users2.get(0).getUserid());
-        }
+        assertTrue(users.size() > 0);
     }
 
     @Test
-    @Ignore
-    public void testGet2() {
+    public void testGet() {
+        // useridを指定して取得
+        UserGetParam param = new UserGetParam();
+        param.setUserids(Arrays.asList("1"));
+        param.setOutput("extend");
+
+        List<User> users = client.user().get(param);
+        assertEquals(1, users.size());
+        assertEquals("1", users.get(0).getUserid());
+    }
+
+    @Test
+    public void testGetNotExist() {
         // 存在しないuseridを指定した場合
         UserGetParam param = new UserGetParam();
-        List<String> userids = new ArrayList<String>();
-        userids.add("999999");
-        param.setUserids(userids);
+        param.setUserids(Arrays.asList("999999"));
+        param.setOutput("extend");
+
         List<User> users = client.user().get(param);
         assertEquals(0, users.size());
     }
 
     @Test
-    @Ignore
     public void testCreateUpdateDelete() {
         // Create
-        UserCreateParam param = new UserCreateParam();
-        param.setAlias("alias1");
-        List<String> userids = client.user().create(param);
-        for (String id : userids) {
-            log.trace(id);
-        }
-        assertEquals(1, userids.size());
+        String userid;
+        {
+            UserCreateParam param = new UserCreateParam();
+            param.setAlias("alias1");
+            param.setName("name1");
+            param.setSurname("surname1");
+            param.setPasswd("passwd1");
+            param.setUrl("url1");
+            param.setAutologin(0);
+            param.setAutologout(1200);
+            param.setLang("ja_jp");
+            param.setRefresh(60);
+            param.setType(2);
+            param.setTheme("css_ob.css");
+            param.setRowsPerPage(100);
 
-        String userid = userids.get(0);
+            List<String> userids = client.user().create(param);
+            assertEquals(1, userids.size());
+
+            userid = userids.get(0);
+        }
+
+        // Get
+        {
+            UserGetParam param = new UserGetParam();
+            param.setUserids(Arrays.asList(userid));
+            param.setOutput("extend");
+
+            List<User> users = client.user().get(param);
+            assertEquals(1, users.size());
+
+            User user = users.get(0);
+            assertEquals(userid, user.getUserid());
+            assertEquals("alias1", user.getAlias());
+            assertEquals("name1", user.getName());
+            assertEquals("surname1", user.getSurname());
+            //assertEquals("passwd1", user.getPasswd());　// Zabbixでハッシュ化されるため検証不能
+            assertEquals("url1", user.getUrl());
+            assertEquals(0, user.getAutologin().intValue());
+            assertEquals(1200, user.getAutologout().intValue());
+            assertEquals("ja_jp", user.getLang());
+            assertEquals(60, user.getRefresh().intValue());
+            assertEquals(2, user.getType().intValue());
+            assertEquals("css_ob.css", user.getTheme());
+            assertEquals(100, user.getRowsPerPage().intValue());
+        }
 
         // Update
-        UserUpdateParam param2 = new UserUpdateParam();
-        param2.setUserid(userid);
-        param2.setAlias("alias2");
-        List<String> userid2 = client.user().update(param2);
-        for (String id : userid2) {
-            log.trace(id);
+        {
+            UserUpdateParam param = new UserUpdateParam();
+            param.setUserid(userid);
+            param.setAlias("alias2");
+            param.setName("name2");
+            param.setSurname("surname2");
+            param.setPasswd("passwd2");
+            param.setUrl("url2");
+            param.setAutologin(1);
+            param.setAutologout(0);
+            param.setLang("en_gb");
+            param.setRefresh(120);
+            param.setType(3);
+            param.setTheme("css_bb.css");
+            param.setRowsPerPage(200);
+
+            List<String> userids = client.user().update(param);
+            assertEquals(1, userids.size());
+            assertEquals(userid, userids.get(0));
         }
-        assertEquals(1, userid2.size());
-        assertEquals(userid, userid2.get(0));
+
+        // Get
+        {
+            UserGetParam param = new UserGetParam();
+            param.setUserids(Arrays.asList(userid));
+            param.setOutput("extend");
+
+            List<User> users = client.user().get(param);
+            assertEquals(1, users.size());
+
+            User user = users.get(0);
+            assertEquals("alias2", user.getAlias());
+            assertEquals("name2", user.getName());
+            assertEquals("surname2", user.getSurname());
+            //assertEquals("passwd2", user.getPasswd());　// Zabbixでハッシュ化されるため検証不能
+            assertEquals("url2", user.getUrl());
+            assertEquals(1, user.getAutologin().intValue());
+            assertEquals(0, user.getAutologout().intValue());
+            assertEquals("en_gb", user.getLang());
+            assertEquals(120, user.getRefresh().intValue());
+            assertEquals(3, user.getType().intValue());
+            assertEquals("css_bb.css", user.getTheme());
+            assertEquals(200, user.getRowsPerPage().intValue());
+        }
 
         // Delete
-        List<String> userid3 = client.user().delete(Arrays.asList(userid));
-        for (String id : userid3) {
-            log.trace(id);
+        {
+            List<String> userids = client.user().delete(Arrays.asList(userid));
+            assertEquals(1, userids.size());
+            assertEquals(userid, userids.get(0));
         }
-        assertEquals(1, userid3.size());
-        assertEquals(userid, userid3.get(0));
+
+        // Get
+        {
+            UserGetParam param = new UserGetParam();
+            param.setUserids(Arrays.asList(userid));
+            param.setOutput("extend");
+
+            List<User> users = client.user().get(param);
+            assertEquals(0, users.size());
+        }
     }
 
     @Test
-    @Ignore
-    public void testCreate() {
+    public void testCreateIllegalArgument() {
         // aliasを指定していない場合
         UserCreateParam param = new UserCreateParam();
-        param.setName("name1");
+
         try {
             client.user().create(param);
             fail();
@@ -186,32 +264,36 @@ public class UserClientTest {
     }
 
     @Test
-    @Ignore
-    public void testCreate2() {
+    public void testCreateExistAlias() {
         // 事前準備
-        UserCreateParam param = new UserCreateParam();
-        param.setAlias("alias1");
-        List<String> userids = client.user().create(param);
-        String userid = userids.get(0);
+        String userid;
+        {
+            UserCreateParam param = new UserCreateParam();
+            param.setAlias("alias1");
+            List<String> userids = client.user().create(param);
+            userid = userids.get(0);
+        }
+
         // 存在するaliasを指定した場合
         try {
-            UserCreateParam param2 = new UserCreateParam();
-            param2.setAlias("alias1");
-            client.user().create(param2);
+            UserCreateParam param = new UserCreateParam();
+            param.setAlias("alias1");
+            client.user().create(param);
             fail();
         } catch (Exception ignore) {
             log.trace(ignore.getMessage());
         } finally {
+            // 事後始末
             client.user().delete(Arrays.asList(userid));
         }
     }
 
     @Test
-    @Ignore
-    public void testUpdate() {
+    public void testUpdateIllegalArgument() {
         // useridを指定していない場合
         UserUpdateParam param = new UserUpdateParam();
         param.setAlias("alias1");
+
         try {
             client.user().update(param);
             fail();
@@ -221,39 +303,45 @@ public class UserClientTest {
     }
 
     @Test
-    @Ignore
-    public void testUpdate2() {
+    public void testUpdateExistAlias() {
         // 事前準備
-        UserCreateParam param = new UserCreateParam();
-        param.setAlias("alias1");
-        List<String> userids = client.user().create(param);
-        String userid = userids.get(0);
+        String userid;
+        {
+            UserCreateParam param = new UserCreateParam();
+            param.setAlias("alias1");
+            List<String> userids = client.user().create(param);
+            userid = userids.get(0);
+        }
 
-        UserCreateParam param2 = new UserCreateParam();
-        param2.setAlias("alias2");
-        String userid2 = client.user().create(param2).get(0);
+        String userid2;
+        {
+            UserCreateParam param = new UserCreateParam();
+            param.setAlias("alias2");
+            List<String> userids = client.user().create(param);
+            userid2 = userids.get(0);
+        }
 
         // 存在するaliasを指定した場合
         try {
-            UserUpdateParam param3 = new UserUpdateParam();
-            param3.setUserid(userid2);
-            param3.setAlias("alias1");
-            client.user().update(param3);
+            UserUpdateParam param = new UserUpdateParam();
+            param.setUserid(userid2);
+            param.setAlias("alias1");
+            client.user().update(param);
             fail();
         } catch (Exception ignore) {
             log.trace(ignore.getMessage());
         } finally {
-            client.user().delete(Arrays.asList(userid));
-            client.user().delete(Arrays.asList(userid2));
+            // 事後始末
+            client.user().delete(Arrays.asList(userid, userid2));
         }
     }
 
     @Test
-    @Ignore
-    public void testUpdate3() {
+    public void testUpdateNotExist() {
         // 存在しないuseridを指定した場合
         UserUpdateParam param = new UserUpdateParam();
         param.setUserid("999999");
+
         try {
             client.user().update(param);
             fail();
@@ -263,8 +351,7 @@ public class UserClientTest {
     }
 
     @Test
-    @Ignore
-    public void testDelete() {
+    public void testDeleteIllegalArgument() {
         // useridを指定していない場合
         try {
             client.user().delete(null);
@@ -275,11 +362,14 @@ public class UserClientTest {
     }
 
     @Test
-    @Ignore
-    public void testDelete2() {
+    public void testDeleteNotExist() {
         // 存在しないuseridを指定した場合
-        List<String> userid = client.user().delete(Arrays.asList("999999"));
-        assertEquals(0, userid.size());
+        try {
+            client.user().delete(Arrays.asList("999999"));
+            //fail(); // エラーは発生しない
+        } catch (Exception ignore) {
+            log.trace(ignore.getMessage());
+        }
     }
 
 }

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/UsergroupClientTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/client/UsergroupClientTest.java
@@ -19,25 +19,26 @@
 package jp.primecloud.auto.zabbix.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
 import jp.primecloud.auto.zabbix.ZabbixClient;
 import jp.primecloud.auto.zabbix.ZabbixClientFactory;
-import jp.primecloud.auto.zabbix.client.UsergroupClient;
 import jp.primecloud.auto.zabbix.model.usergroup.Usergroup;
+import jp.primecloud.auto.zabbix.model.usergroup.UsergroupCreateParam;
 import jp.primecloud.auto.zabbix.model.usergroup.UsergroupGetParam;
+import jp.primecloud.auto.zabbix.model.usergroup.UsergroupUpdateParam;
 
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-
 
 /**
  * <p>
@@ -68,38 +69,249 @@ public class UsergroupClientTest {
     }
 
     @Test
-    @Ignore
-    public void testGet() {
+    public void testGetAll() {
         // 全件取得
         UsergroupGetParam param = new UsergroupGetParam();
         param.setOutput("extend");
+
         List<Usergroup> usergroups = client.usergroup().get(param);
         for (Usergroup usergroup : usergroups) {
             log.trace(ReflectionToStringBuilder.toString(usergroup, ToStringStyle.SHORT_PREFIX_STYLE));
         }
 
-        if (usergroups.size() > 0) {
-            // usergroupidを指定して取得
-            List<String> usergroupids = new ArrayList<String>();
-            usergroupids.add(usergroups.get(0).getUsrgrpid());
-            param.setUsrgrpids(usergroupids);
-            List<Usergroup> usergroups2 = client.usergroup().get(param);
+        assertTrue(usergroups.size() > 0);
+    }
 
-            assertEquals(1, usergroups2.size());
-            assertEquals(usergroups.get(0).getUsrgrpid(), usergroups2.get(0).getUsrgrpid());
+    @Test
+    public void testGet() {
+        // usrgrpidを指定して取得
+        UsergroupGetParam param = new UsergroupGetParam();
+        param.setUsrgrpids(Arrays.asList("8"));
+        param.setOutput("extend");
+
+        List<Usergroup> usergroups = client.usergroup().get(param);
+        assertEquals(1, usergroups.size());
+        assertEquals("8", usergroups.get(0).getUsrgrpid());
+    }
+
+    @Test
+    public void testGetNotExist() {
+        // 存在しないusrgrpidを指定した場合
+        UsergroupGetParam param = new UsergroupGetParam();
+        param.setUsrgrpids(Arrays.asList("999999"));
+        param.setOutput("extend");
+
+        List<Usergroup> usergroups = client.usergroup().get(param);
+        assertEquals(0, usergroups.size());
+    }
+
+    @Test
+    public void testCreateUpdateDelete() {
+        // Create
+        String usrgrpid;
+        {
+            UsergroupCreateParam param = new UsergroupCreateParam();
+            param.setName("name1");
+            param.setGuiAccess(1);
+            param.setUsersStatus(1);
+            param.setApiAccess(1);
+            param.setDebugMode(1);
+
+            List<String> usrgrpids = client.usergroup().create(param);
+            assertEquals(1, usrgrpids.size());
+
+            usrgrpid = usrgrpids.get(0);
+        }
+
+        // Get
+        {
+            UsergroupGetParam param = new UsergroupGetParam();
+            param.setUsrgrpids(Arrays.asList(usrgrpid));
+            param.setOutput("extend");
+
+            List<Usergroup> usergroups = client.usergroup().get(param);
+            assertEquals(1, usergroups.size());
+
+            Usergroup usergroup = usergroups.get(0);
+            assertEquals(usrgrpid, usergroup.getUsrgrpid());
+            assertEquals("name1", usergroup.getName());
+            assertEquals(1, usergroup.getGuiAccess().intValue());
+            assertEquals(1, usergroup.getUsersStatus().intValue());
+            assertEquals(1, usergroup.getApiAccess().intValue());
+            assertEquals(1, usergroup.getDebugMode().intValue());
+
+        }
+
+        // Update
+        {
+            UsergroupUpdateParam param = new UsergroupUpdateParam();
+            param.setUsrgrpid(usrgrpid);
+            param.setName("name2");
+            param.setGuiAccess(0);
+            param.setUsersStatus(0);
+            param.setApiAccess(0);
+            param.setDebugMode(0);
+
+            List<String> usrgrpids = client.usergroup().update(param);
+            assertEquals(1, usrgrpids.size());
+            assertEquals(usrgrpid, usrgrpids.get(0));
+        }
+
+        // Get
+        {
+            UsergroupGetParam param = new UsergroupGetParam();
+            param.setUsrgrpids(Arrays.asList(usrgrpid));
+            param.setOutput("extend");
+
+            List<Usergroup> usergroups = client.usergroup().get(param);
+            assertEquals(1, usergroups.size());
+
+            Usergroup usergroup = usergroups.get(0);
+            assertEquals(usrgrpid, usergroup.getUsrgrpid());
+            assertEquals("name2", usergroup.getName());
+            assertEquals(0, usergroup.getGuiAccess().intValue());
+            assertEquals(0, usergroup.getUsersStatus().intValue());
+            assertEquals(0, usergroup.getApiAccess().intValue());
+            assertEquals(0, usergroup.getDebugMode().intValue());
+        }
+
+        // Delete
+        {
+            List<String> usrgrpids = client.usergroup().delete(Arrays.asList(usrgrpid));
+            assertEquals(1, usrgrpids.size());
+            assertEquals(usrgrpid, usrgrpids.get(0));
+        }
+
+        // Get
+        {
+            UsergroupGetParam param = new UsergroupGetParam();
+            param.setUsrgrpids(Arrays.asList(usrgrpid));
+            param.setOutput("extend");
+
+            List<Usergroup> usergroups = client.usergroup().get(param);
+            assertEquals(0, usergroups.size());
         }
     }
 
     @Test
-    @Ignore
-    public void testGet2() {
-        // 存在しないusergroupidを指定した場合
-        UsergroupGetParam param = new UsergroupGetParam();
-        List<String> usergroupids = new ArrayList<String>();
-        usergroupids.add("999999");
-        param.setUsrgrpids(usergroupids);
-        List<Usergroup> usergroups = client.usergroup().get(param);
-        assertEquals(0, usergroups.size());
+    public void testCreateIllegalArgument() {
+        // nameを指定していない場合
+        UsergroupCreateParam param = new UsergroupCreateParam();
+
+        try {
+            client.usergroup().create(param);
+            fail();
+        } catch (IllegalArgumentException ignore) {
+            log.trace(ignore.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateExistName() {
+        // 事前準備
+        String usrgrpid;
+        {
+            UsergroupCreateParam param = new UsergroupCreateParam();
+            param.setName("name1");
+            List<String> usrgrpids = client.usergroup().create(param);
+            usrgrpid = usrgrpids.get(0);
+        }
+
+        // 存在するnameを指定した場合
+        try {
+            UsergroupCreateParam param = new UsergroupCreateParam();
+            param.setName("name1");
+            client.usergroup().create(param);
+            fail();
+        } catch (Exception ignore) {
+            log.trace(ignore.getMessage());
+        } finally {
+            // 事後始末
+            client.usergroup().delete(Arrays.asList(usrgrpid));
+        }
+    }
+
+    @Test
+    public void testUpdateIllegalArgument() {
+        // usrgrpidを指定していない場合
+        UsergroupUpdateParam param = new UsergroupUpdateParam();
+
+        try {
+            client.usergroup().update(param);
+            fail();
+        } catch (IllegalArgumentException ignore) {
+            log.trace(ignore.getMessage());
+        }
+    }
+
+    @Test
+    public void testUpdateExistName() {
+        // 事前準備
+        String usrgrpid;
+        {
+            UsergroupCreateParam param = new UsergroupCreateParam();
+            param.setName("name1");
+            List<String> usrgrpids = client.usergroup().create(param);
+            usrgrpid = usrgrpids.get(0);
+        }
+
+        String usrgrpid2;
+        {
+            UsergroupCreateParam param = new UsergroupCreateParam();
+            param.setName("name2");
+            List<String> usrgrpids = client.usergroup().create(param);
+            usrgrpid2 = usrgrpids.get(0);
+        }
+
+        // 存在するnameを指定した場合
+        try {
+            UsergroupUpdateParam param = new UsergroupUpdateParam();
+            param.setUsrgrpid(usrgrpid2);
+            param.setName("name1");
+            client.usergroup().update(param);
+            fail();
+        } catch (Exception ignore) {
+            log.trace(ignore.getMessage());
+        } finally {
+            // 事後始末
+            client.usergroup().delete(Arrays.asList(usrgrpid, usrgrpid2));
+        }
+    }
+
+    @Test
+    public void testUpdateNotExist() {
+        // 存在しないusrgrpidを指定した場合
+        UsergroupUpdateParam param = new UsergroupUpdateParam();
+        param.setUsrgrpid("999999");
+
+        try {
+            client.usergroup().update(param);
+            //fail(); // エラーは発生しない
+        } catch (Exception ignore) {
+            log.trace(ignore.getMessage());
+        }
+    }
+
+    @Test
+    public void testDeleteIllegalArgument() {
+        // useridを指定していない場合
+        try {
+            client.usergroup().delete(null);
+            fail();
+        } catch (IllegalArgumentException ignore) {
+            log.trace(ignore.getMessage());
+        }
+    }
+
+    @Test
+    public void testDeleteNotExist() {
+        // 存在しないusrgrpidを指定した場合
+        try {
+            client.usergroup().delete(Arrays.asList("999999"));
+            //fail(); // エラーは発生しない
+        } catch (IllegalArgumentException ignore) {
+            log.trace(ignore.getMessage());
+        }
     }
 
 }

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/util/JavaPropertyNameProcessorTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/util/JavaPropertyNameProcessorTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * <p>
- * TODO: クラスコメントを記述
+ * {@link JavaPropertyNameProcessor}のテストクラスです。
  * </p>
  *
  */

--- a/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/util/JsonPropertyNameProcessorTest.java
+++ b/auto-project/auto-zabbix/src/test/java/jp/primecloud/auto/zabbix/util/JsonPropertyNameProcessorTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * <p>
- * TODO: クラスコメントを記述
+ * {@link JsonPropertyNameProcessor}のテストクラスです。
  * </p>
  *
  */

--- a/auto-project/auto-zabbix/src/test/resources/zabbix.properties
+++ b/auto-project/auto-zabbix/src/test/resources/zabbix.properties
@@ -1,3 +1,3 @@
-zabbix.url = http://172.22.0.23/zabbix/
-zabbix.username = auto
-zabbix.password = ****
+zabbix.url = http://localhost/zabbix/
+zabbix.username = api
+zabbix.password = password

--- a/auto-tool/management-tool/src/main/java/jp/primecloud/auto/tool/management/zabbix/ZabbixScriptService.java
+++ b/auto-tool/management-tool/src/main/java/jp/primecloud/auto/tool/management/zabbix/ZabbixScriptService.java
@@ -65,9 +65,14 @@ public class ZabbixScriptService {
         userCreateParam.setName(name);
         userCreateParam.setSurname(surname);
         userCreateParam.setPasswd(password);
-        userCreateParam.setLang("ja_jp");
         userCreateParam.setUrl("overview.php");
         userCreateParam.setUsrgrps(usergroups);
+
+        if (zabbixClient.checkVersion("2.0.0") < 0) {
+            userCreateParam.setLang("ja_jp");
+        } else {
+            userCreateParam.setLang("ja_JP");
+        }
 
         List<String> users = zabbixClient.user().create(userCreateParam);
        


### PR DESCRIPTION
後方互換性を保持した上で、Zabbix Server 2.2.X で動作するようにしました。
（動作確認は 1.8.15 および 2.2.9 にて実施しました。）

Zabbix Server のバージョンなどを設定ファイルで指定する必要はなく、APIを利用してバージョンをチェックした上で、バージョンに応じた適切なAPI実行を行うようにしています。
