### PR TITLE
Fix a bug that different Zabbix proxy is used.

### DIFF
--- a/auto-project/auto-process/src/main/java/jp/primecloud/auto/process/zabbix/ZabbixProcessClient.java
+++ b/auto-project/auto-process/src/main/java/jp/primecloud/auto/process/zabbix/ZabbixProcessClient.java
@@ -71,9 +71,9 @@ public class ZabbixProcessClient {
 
     public Proxy getProxy(String proxyName) {
         ProxyGetParam param = new ProxyGetParam();
-        Map<String, List<Object>> search = new HashMap<String, List<Object>>();
-        search.put("host", Arrays.asList((Object)proxyName));
-        param.setSearch(search);
+        Map<String, List<Object>> filter = new HashMap<String, List<Object>>();
+        filter.put("host", Arrays.asList((Object)proxyName));
+        param.setFilter(filter);
         param.setOutput("extend");
 
         List<Proxy> proxies = zabbixClient.proxy().get(param);


### PR DESCRIPTION
Zabbix Server上にZabbix Proxyが複数登録されている場合、"config.properties" ファイルで指定したProxyとは異なるものが利用されてしまうことがある不具合を修正しました。