### PR TITLE
Fix a bug that inconsistency will occur between database and cloud status when error raised.

### DIFF
--- a/iaas-gw/src/iaasgw/db/mysqlConnector.py
+++ b/iaas-gw/src/iaasgw/db/mysqlConnector.py
@@ -67,7 +67,7 @@ class MysqlConnector(object):
         table_object = Table(tableName, METADATA, autoload=True)
         return table_object
 
-    def execute(self, sql, autocommit = False):
+    def execute(self, sql, autocommit = True):
         res = self.session.execute(sql)
         if autocommit == True:
             self.commit();


### PR DESCRIPTION
IaaS GatewayにおけるMySQL接続で "autocommit" が False となっているため、IaaS Gatewayの中でエラーが発生するとデータベース更新がロールバックされることにより、クラウドの状態とデータベースに不整合が生じるケースがあります。

例えば、EC2インスタンスを起動し、データベース更新をした後に何らかのエラーが発生した場合、更新がロールバックされるためにインスタンスIDなどはデータベースに記録されませんが、EC2インスタンスは起動したままになってしまいます。
この後、PCC画面上からサーバ停止操作をしたとしても、インスタンスIDが記録されていないために、PCCはEC2インスタンスを停止することなく、PCC画面上ではサーバは停止状態となってしまいます。

上記は例ですが、実際には、1度のIaaS Gateway呼び出しの中で複数回のクラウド操作を行っている場合に発生し得ます。
このような不整合を防ぐために "autocommit" を True とするのが良いかと思います。