### PR TITLE
Bugfix ddl

### DIFF
--- a/sql/adc/010-table/aws_load_balancer.sql
+++ b/sql/adc/010-table/aws_load_balancer.sql
@@ -7,5 +7,6 @@ create table AWS_LOAD_BALANCER (
     AVAILABILITY_ZONE varchar(100),
     HOSTID varchar(20),
     STATUS varchar(20),
+    INTERNAL tinyint(1) not null default '0',
     constraint AWS_LOAD_BALANCER_PK primary key(LOAD_BALANCER_NO)
 );

--- a/sql/adc/050-foreignkey/aws_ssl_key.sql
+++ b/sql/adc/050-foreignkey/aws_ssl_key.sql
@@ -1,2 +1,2 @@
-#alter table AWS_SSL_KEY add constraint AWS_SSL_KEY_FK1 foreign key (FARM_NO) references FARM (FARM_NO);
-#alter table AWS_SSL_KEY add constraint AWS_SSL_KEY_FK2 foreign key (PLATFORM_NO) references PLATFORM (PLATFORM_NO);
+alter table AWS_SSL_KEY add constraint AWS_SSL_KEY_FK1 foreign key (FARM_NO) references FARM (FARM_NO);
+alter table AWS_SSL_KEY add constraint AWS_SSL_KEY_FK2 foreign key (PLATFORM_NO) references PLATFORM (PLATFORM_NO);


### PR DESCRIPTION
AWS_SSL_KEYテーブルの定義が不足していた為、追加しました。
* `INTERNAL`カラムの追加
* 外部キー制約の追加