### PR TITLE
Improve validation of InstanceType without using awssdk.

### DIFF
--- a/auto-project/auto-service/src/main/java/jp/primecloud/auto/service/dto/ZoneDto.java
+++ b/auto-project/auto-service/src/main/java/jp/primecloud/auto/service/dto/ZoneDto.java
@@ -20,8 +20,6 @@ package jp.primecloud.auto.service.dto;
 
 import java.io.Serializable;
 
-import com.amazonaws.services.ec2.model.AvailabilityZone;
-
 public class ZoneDto implements Serializable {
 
     /** TODO: フィールドコメントを記述 */


### PR DESCRIPTION
auto-service内のEC2インスタンスのInstanceTypeの入力チェックを行う箇所において、awssdkを利用せずに、IMAGE_AWSテーブルに登録されているInstanceTypeリストに合致するかをチェックするように変更しました。

また、不要なimport文を削除し、auto-serviceがawssdkを直接参照しないようにしました。
