### PR TITLE
revised install.sh

### DIFF
--- a/auto-tool/install-tool/src/main/scripts/install.sh
+++ b/auto-tool/install-tool/src/main/scripts/install.sh
@@ -559,7 +559,7 @@ cd ${SOFTWARE_DIR}/python/Python-${PYTHON_VERSION}
 ${SOFTWARE_DIR}/python/Python-${PYTHON_VERSION}/configure --with-threads --enable-shared >> $LOG_FILE 2>&1
 
 #openssl setting
-OPENSSL_DIR=`sudo find / -name openssl | grep include | sed -e "s/\/include\/.*//"`
+OPENSSL_DIR=`find / -path "/var/named" -prune -o -name openssl | grep include | sed -e "s/\/include\/.*//"`
 if [ -n "$OPENSSL_DIR" ]; then
     sed -i -e "s%#SSL=/usr/local/ssl%SSL=$OPENSSL_DIR%" ${SOFTWARE_DIR}/python/Python-${PYTHON_VERSION}/Modules/Setup
     sed -i -e 's%#_ssl _ssl.c \\%_ssl _ssl.c \\%' ${SOFTWARE_DIR}/python/Python-${PYTHON_VERSION}/Modules/Setup
@@ -582,9 +582,9 @@ cp -p ${SOFTWARE_DIR}/python/python-${PYTHON_VERSION}.conf /etc/ld.so.conf.d/pyt
 ldconfig
 
 #install ez_setup and pip
-which pip > /dev/null
+which pip > /dev/null 2>&1
 if [ $? -ne 0 ]; then
-    wget https://bootstrap.pypa.io/ez_setup.py -O - | python >> $LOG_FILE 2>&1
+    wget https://bootstrap.pypa.io/ez_setup.py -q -O - | python >> $LOG_FILE 2>&1
     if [ $? -ne 0 ]; then
         echo "Error: python ez_setup install failed." >> $LOG_FILE 2>&1
         echo "Error: python ez_setup install failed."
@@ -613,7 +613,7 @@ fi
 easy_install apache-libcloud\=\=${LIBCLOUD_VERSION} >> $LOG_FILE 2&>1
 
 #install mysql-connector
-wget https://launchpad.net/myconnpy/0.3/0.3.2/+download/mysql-connector-python-0.3.2-devel.tar.gz
+wget -q https://launchpad.net/myconnpy/0.3/0.3.2/+download/mysql-connector-python-0.3.2-devel.tar.gz
 easy_install -Z mysql-connector-python-0.3.2-devel.tar.gz >> $LOG_FILE 2>&1
 #easy_install mysql-connector-python\=\=${MYSQL_CONNECTOR_PYTHON_VERSION} >> $LOG_FILE 2&>1
 
@@ -736,9 +736,8 @@ ln -s management-tool-${PCC_VERSION} management-tool
 chmod a+x /opt/adc/management-tool/bin/*.sh
 
 ## install auto-cli
-tar zxvf ${SOFTWARE_DIR}/pcc/auto-cli-${PCC_VERSION}.tar.gz >> $LOG_FILE 2>&1
-mv auto-cli-${PCC_VERSION} /opt/adc
 cd /opt/adc
+tar zxvf ${SOFTWARE_DIR}/pcc/auto-cli-${PCC_VERSION}.tar.gz >> $LOG_FILE 2>&1
 ln -s auto-cli-${PCC_VERSION} auto-cli
 chmod a+x /opt/adc/auto-cli/bin/*
 


### PR DESCRIPTION
インストールスクリプト内のbugを修正。

* 修正前の出力

```
====START :install python====
find: File system loop detected; `/var/named/chroot/var/named' is part of the same file system loop as `/var/named'.
====START :make python====
which: no pip in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin)
--2016-04-12 07:53:01--  https://bootstrap.pypa.io/ez_setup.py
Resolving bootstrap.pypa.io... 103.245.222.175
Connecting to bootstrap.pypa.io|103.245.222.175|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 12059 (12K) [text/x-python]
Saving to: “STDOUT”

100%[=================================================================================================================================================>] 12,059      --.-K/s   in 0s

2016-04-12 07:53:01 (1.05 GB/s) - written to stdout [12059/12059]

--2016-04-12 07:53:10--  https://launchpad.net/myconnpy/0.3/0.3.2/+download/mysql-connector-python-0.3.2-devel.tar.gz
Resolving launchpad.net... 91.189.89.223, 91.189.89.222
Connecting to launchpad.net|91.189.89.223|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://launchpadlibrarian.net/62023522/mysql-connector-python-0.3.2-devel.tar.gz [following]
--2016-04-12 07:53:11--  https://launchpadlibrarian.net/62023522/mysql-connector-python-0.3.2-devel.tar.gz
Resolving launchpadlibrarian.net... 91.189.89.229, 91.189.89.228
Connecting to launchpadlibrarian.net|91.189.89.229|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 129408 (126K) [application/x-tar]
Saving to: “mysql-connector-python-0.3.2-devel.tar.gz”

100%[=================================================================================================================================================>] 129,408     90.2K/s   in 1.4s

2016-04-12 07:53:14 (90.2 KB/s) - “mysql-connector-python-0.3.2-devel.tar.gz” saved [129408/129408]

====success             :install python====
====success             :install pcc====
====START :install management-tool ====
mv: `auto-cli-2.6.0' and `/opt/adc/auto-cli-2.6.0' are the same file
====end :install management-tool ====
====success             : create adc tables
====success             : insert default sample data
-----------------------------------------------------------

````


* 修正後の出力

```
-----------------------------------------------------------
====START :install python====
====START :make python====
====success             :install python====
====success             :install pcc====
====START :install management-tool ====
====end :install management-tool ====
====success             : create adc tables
====success             : insert default sample data
-----------------------------------------------------------
Install Process finished.
```

