### PR TITLE
Improve host-init script for if '/root/script' directory does not exist.

### DIFF
--- a/script/host-init/host-init.sh.aws
+++ b/script/host-init/host-init.sh.aws
@@ -112,6 +112,10 @@ fi
 #execute init script
 SCRIPTDIR=/root/script
 
+if [ ! -e $SCRIPTDIR ]; then
+    mkdir -p $SCRIPTDIR
+fi
+
 if [ -n "$SCRIPTSERVER" ]; then
     #get script
     wget -q --connect-timeout=30 --tries=4 --spider http://$SCRIPTSERVER/script/init.sh

--- a/script/host-init/host-init.sh.cs
+++ b/script/host-init/host-init.sh.cs
@@ -113,6 +113,10 @@ fi
 #execute init script
 SCRIPTDIR=/root/script
 
+if [ ! -e $SCRIPTDIR ]; then
+    mkdir -p $SCRIPTDIR
+fi
+
 if [ -n "$SCRIPTSERVER" ]; then
     #get script
     wget -q --connect-timeout=30 --tries=4 --spider http://$SCRIPTSERVER/script/init.sh

--- a/script/host-init/host-init.sh.nifty
+++ b/script/host-init/host-init.sh.nifty
@@ -95,6 +95,10 @@ fi
 #execute init script
 SCRIPTDIR=/root/script
 
+if [ ! -e $SCRIPTDIR ]; then
+    mkdir -p $SCRIPTDIR
+fi
+
 if [ -n "$SCRIPTSERVER" ]; then
     #get script
     wget -q --connect-timeout=30 --tries=4 --spider http://$SCRIPTSERVER/script/init.sh

--- a/script/host-init/host-init.sh.vcloud
+++ b/script/host-init/host-init.sh.vcloud
@@ -136,6 +136,10 @@ fi
 #execute init script
 SCRIPTDIR=/root/script
 
+if [ ! -e $SCRIPTDIR ]; then
+    mkdir -p $SCRIPTDIR
+fi
+
 if [ -n "$SCRIPTSERVER" ]; then
     #get script
     WGET_LOG=/tmp/hostinit-wget.log

--- a/script/host-init/host-init.sh.vmware
+++ b/script/host-init/host-init.sh.vmware
@@ -100,6 +100,10 @@ fi
 #execute init script
 SCRIPTDIR=/root/script
 
+if [ ! -e $SCRIPTDIR ]; then
+    mkdir -p $SCRIPTDIR
+fi
+
 if [ -n "$SCRIPTSERVER" ]; then
     #get script
     wget -q --connect-timeout=30 --tries=4 --spider http://$SCRIPTSERVER/script/init.sh


### PR DESCRIPTION
インスタンス内に /root/script ディレクトリが存在しない場合、PCCによる初期化処理が正常に行われないため、起動処理の中で /root/script ディレクトリを作成するようにしました。